### PR TITLE
Update Sphinx build to use Documenteer 0.6 and later

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,10 +1,4 @@
-import sys
-
 import lsst_sphinx_bootstrap_theme
-
-
-# Work around Sphinx bug related to large and highly-nested source files
-sys.setrecursionlimit(2000)
 
 # -- General configuration ------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -76,15 +76,6 @@ rst_epilog = """
 
 """
 
-# -- Options for linkcheck builder ----------------------------------------
-
-linkcheck_retries = 2
-linkcheck_timeout = 5  # seconds
-linkcheck_ignore = [
-    r"^http://localhost",
-    r"http://amor01.cp.lsst.org/login",
-]
-
 # -- Options for HTML output ----------------------------------------------
 
 templates_path = ["_templates", lsst_sphinx_bootstrap_theme.get_html_templates_path()]
@@ -126,6 +117,11 @@ html_static_path = []
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 
+# -- Options for linkcheck builder ----------------------------------------
+
+linkcheck_retries = 2
+linkcheck_timeout = 5  # seconds
+
 linkcheck_ignore = [
     r"http://amor01.cp.lsst.org/*",
     r"http://localhost:\d+/*",
@@ -156,4 +152,5 @@ linkcheck_ignore = [
     r"https://rancher.tu.lsst.org",
     r"https://rancher.ls.lsst.org",
     r"https://tssw-ci.lsst.org/",
+    r"^https://lsstit.1password.com",
 ]

--- a/conf.py
+++ b/conf.py
@@ -147,4 +147,5 @@ linkcheck_ignore = [
     r"https://rancher.ls.lsst.org",
     r"https://tssw-ci.lsst.org/",
     r"^https://lsstit.1password.com",
+    r"^ls.st",  # TLS cert on ls.st is invalid and may cause issues
 ]

--- a/project/license.rst
+++ b/project/license.rst
@@ -4,4 +4,4 @@ Documentation license
 
 The content of `obs-ops.lsst.io <https://obs-ops.lsst.io>`__ (`lsst-ts/observatory-ops-docs on GitHub <observatory-ops-docs>`__) is licensed under a Creative Commons Attribution 4.0 International license (CC-BY).
 
-`View the license. <https://github.com/lsst-ts/observatory-ops-docs/blob/master/LICENSE>`__
+`View the license. <https://github.com/lsst-ts/observatory-ops-docs/blob/main/LICENSE>`__

--- a/project/license.rst
+++ b/project/license.rst
@@ -2,6 +2,6 @@
 Documentation license
 #####################
 
-The content of `obs-ops.lsst.io <https://obs-ops.lsst.io>`__ (`lsst-ts/observatory-ops-docs on GitHub <observatory-ops-docs>`__) is licensed under a Creative Commons Attribution 4.0 International license (CC-BY).
+The content of `obs-ops.lsst.io <https://obs-ops.lsst.io>`__ (`lsst-ts/observatory-ops-docs on GitHub <https://github.com/lsst-ts/observatory-ops-docs>`__) is licensed under a Creative Commons Attribution 4.0 International license (CC-BY).
 
 `View the license. <https://github.com/lsst-ts/observatory-ops-docs/blob/main/LICENSE>`__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-docutils<=0.17.1
-documenteer<0.6.0
+documenteer
 lsst_sphinx_bootstrap_theme
 ltd-conveyor
 sphinx-prompt
-jinja2==3.0.3


### PR DESCRIPTION
- Move the site to the latest versions of Sphinx and documenteer, which no longer require the specific pins in requirements.txt

- Remove unnecessary setrecusionlimit call from `conf.py` 

- Add some extra rules for linkcheck 