### PR TITLE
Tickets/sitcom 1465

### DIFF
--- a/AuxTel/Non-Standard-Operations/EUI-Access/EUI-Access.rst
+++ b/AuxTel/Non-Standard-Operations/EUI-Access/EUI-Access.rst
@@ -48,18 +48,18 @@ Setup to access the AuxTel EUI remote desktop
 
 #. Click :guilabel:`+` button on the top menu.
 
-#. Select "Add PC" from drop-down menu.
+#. Select "Gateway" from drop-down menu.
 
 #. Click the drop-down menu "Gateway" :raw-html:`&rarr;` "No gateway"
 
 .. figure:: /AuxTel/Non-Standard-Operations/_static/image-2023-11-8_17-6-47.png
-  :name: "Add PC" pop-up window
-
-
-#. Put *aux-brick01.cp.lsst.org* on the "Gateway name" :raw-html:`&rarr;` "Add"
-
-.. figure:: /AuxTel/Non-Standard-Operations/_static/image-2023-11-8_17-3-7.png
   :name: "Add a Gateway" pop-up window
+
+
+#. Put *aux-brick01.cp.lsst.org* on the "PC name" :raw-html:`&rarr;` "Save"
+
+.. figure:: /AuxTel/Non-Standard-Operations/_static/Adding_AuxTel_EUI.png
+  :name: "PC name" field
 
 
 .. note::

--- a/AuxTel/Non-Standard-Operations/EUI-Access/EUI-Access.rst
+++ b/AuxTel/Non-Standard-Operations/EUI-Access/EUI-Access.rst
@@ -53,13 +53,13 @@ Setup to access the AuxTel EUI remote desktop
 #. Click the drop-down menu "Gateway" :raw-html:`&rarr;` "No gateway"
 
 .. figure:: /AuxTel/Non-Standard-Operations/_static/image-2023-11-8_17-6-47.png
-  :name: "Add a Gateway" pop-up window
+  :name: "Add a Gateway" pop-up window.
 
 
 #. Put *aux-brick01.cp.lsst.org* on the "PC name" :raw-html:`&rarr;` "Save"
 
 .. figure:: /AuxTel/Non-Standard-Operations/_static/Adding_AuxTel_EUI.png
-  :name: "PC name" field
+  :name: "PC name" field.
 
 
 .. note::

--- a/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.rst
@@ -12,11 +12,13 @@
 
 
 .. _Daytime-Operations-LATISS-Daily-Calibrations-BIAS-DARK-FLAT-all-filters-empty-Procedure:
+
 ##################################################################
 LATISS Daily Calibrations BIAS, DARK and FLAT: all filters + empty
 ##################################################################
 
 .. _Daytime-Operations-LATISS-Daily-Calibrations-BIAS-DARK-FLAT-all-filters-empty-Overview:
+
 Overview
 ========
 This procedure will enable and turn on the ATWhiteLight that illuminates the dome flat screen. It will position the telescope and dome in the FLAT position, and will take BIAS, DARK, and FLATS calibrations images in all installed filters including the empty filter. Finally will turn off the white light and send the ATWhiteLight to ``STANDBY``. After the entire script completion, the telescope and dome will remain in ``ENABLED`` state and in the FLAT field position. The observer can decide whether to vent, proceed to on-sky or shutdown.
@@ -43,232 +45,246 @@ Procedure Steps
 #. Enable ``Scheduler:2`` with a valid scheduler configuration. Use the standard script :file:`auxtel/scheduler/enable.py` with the configuration required for the run and available in the corresponding night log. 
 #. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
 
-.. code-block:: text
-  :caption: :file:`add_block.py`
+    .. code-block:: text
+      :caption: :file:`add_block.py`
 
-  id: latiss_daily_calibrations
+      id: setup_latiss_calibrations
 
+    The BLOCK with :file:`setup_latiss_calibrations` configuration will queue the scripts aimed to setup the system. It will start with the :file:`set_summary_state.py` script to enable ATWhiteLight CSC with the following configuration:
 
-The BLOCK with :file:`latiss_daily_calibrations` configuration will queue the following scripts:
+    .. code-block:: text
+      :caption: :file:`set_summary_state.py`
+    
+      data:
+        -
+          - ATWhiteLight 
+          - ENABLED 
 
-The BLOCK will start with the :file:`set_summary_state.py` script to enable ATWhiteLight CSC with the following configuration:
+    The :file:`set_summary_state.py` script will enable ``OCPS:1`` CSC.
 
-.. code-block:: text
-  :caption: :file:`set_summary_state.py`
- 
-  data:
-     -
-       - ATWhiteLight 
-       - ENABLED 
+    .. code-block:: text
+      :caption: :file:`set_summary_state.py`
+    
+      data:
+        -
+          - OCPS:1
+          - ENABLED
 
-The :file:`set_summary_state.py` script will enable ``OCPS:1`` CSC.
+    The SAL script :file:`auxtel/calibrations/power_on_atcalsys.py` with no configuration inserted into the BLOCK :file:`setup_latiss_calibrations` structure will start the chiller, turn on the white light and open the shutter.  This script takes 15 minutes to complete, the time it takes to warm up the white light. On Chronograf using the query :file:`lsst.sal.ATWhiteLight.logevent_logMessage.message`, the lamp reports its retry loop status explicitly.
 
-.. code-block:: text
-  :caption: :file:`set_summary_state.py`
- 
-  data:
-     -
-       - OCPS:1
-       - ENABLED
+    .. code-block:: text
+      :caption: :file:`auxtel/calibrations/power_on_atcalsys.py`
 
-The SAL script :file:`auxtel/calibrations/power_on_atcalsys.py` with no configuration inserted into the BLOCK :file:`latiss_daily_calibrations` structure will start the chiller, turn on the white light and open the shutter.  This script takes 15 minutes to complete, the time it takes to warm up the white light. On Chronograf using the query :file:`lsst.sal.ATWhiteLight.logevent_logMessage.message`, the lamp reports its retry loop status explicitly.
+    The :file:`auxtel/prepare_for/flat.py` script (empty configuration) will position the telescope and dome in FLAT position. The telescope will point towards the dome flat screen (mount Az = 188.7 deg, mount El = 39.0 deg, dome Az= 2.59 deg). Confirm in the cameras aux-cam01 or aux-cam02 that the white light is on, and telescope is pointing to the dome flat screen.
 
-.. code-block:: text
-  :caption: :file:`auxtel/calibrations/power_on_atcalsys.py`
+    .. code-block:: text
+      :caption: :file:`auxtel/prepare_for/flat.py`
+  
 
+#. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
 
-The :file:`auxtel/prepare_for/flat.py` script (empty configuration) will position the telescope and dome in FLAT position. The telescope will point towards the dome flat screen (mount Az = 188.7 deg, mount El = 39.0 deg, dome Az= 2.59 deg). Confirm in the cameras aux-cam01 or aux-cam02 that the white light is on, and telescope is pointing to the dome flat screen.
+    .. code-block:: text
+      :caption: :file:`add_block.py`
 
-.. code-block:: text
-   :caption: :file:`auxtel/prepare_for/flat.py`
-
-Depending on which filters are currently installed in LATISS, the :file:`auxtel/make_latiss_calibrations.py` script may take different calibration sets. The calibration images displayed in `RubinTV`_ are post-ISR images and should have BIAS and DARK corrections applied. This means that BIAS and DARK images should display with maximum count rates of about 10 ADUs. In the case of FLAT images, counts must be below the :math:`\approx` 30000 ADUs. In the process of building the daily PTC (see below), the FLAT saturation is intended, and achieved at around the 123000 ADUs (with exposure time of about 25 seconds). The daily FLATS reach values of :math:`\approx` 68000 ADUs. If you see large deviations from these values, which can be related with a problem in the instrument signature removal in `RubinTV`_, then RAW count rates are being displayed, please report it. Check the calibration sets and their configurations for each filter installed and the grating.
-
-1. **: Set configuration for SDSSr_65mm.**
-
-.. code-block:: text
-  :caption: :file:`auxtel/make_latiss_calibrations.py`
-
-    n_flat: 20
-    exp_times_flat: 6
-    script_mode: BIAS_DARK_FLAT
-    filter: SDSSr_65mm
-    grating: empty_1
-
-2. **: Set configuration for SDSSg_65mm.**
-
-.. code-block:: text
-  :caption: :file:`auxtel/make_latiss_calibrations.py`
-
-    n_bias: 3
-    n_dark: 3
-    exp_times_dark: 6
-    n_flat: 20
-    exp_times_flat: 6
-    script_mode: BIAS_DARK_FLAT
-    filter: SDSSg_65mm
-    grating: empty_1
+      id: latiss_daily_calibrations
 
 
-3. **: Set configuration for SDSSz_65mm.**
+    The BLOCK with :file:`latiss_daily_calibrations` configuration will queue the scripts focused on the calibration image adquisition. Depending on which filters are currently installed in LATISS, the :file:`auxtel/make_latiss_calibrations.py` script may take different calibration sets. The calibration images displayed in `RubinTV`_ are post-ISR images and should have BIAS and DARK corrections applied. This means that BIAS and DARK images should display with maximum count rates of about 10 ADUs. In the case of FLAT images, counts must be below the :math:`\approx` 30000 ADUs. In the process of building the daily PTC (see below), the FLAT saturation is intended, and achieved at around the 123000 ADUs (with exposure time of about 25 seconds). In case daily FLATS are taken, they reach values of :math:`\approx` 68000 ADUs. If you see large deviations from these values, which can be related with a problem in the instrument signature removal in `RubinTV`_, then RAW count rates are being displayed, please report it. Check the calibration sets and their configurations for each filter installed and the grating.
 
-.. code-block:: text
-  :caption: :file:`auxtel/make_latiss_calibrations.py`
+    1. **: Set configuration for SDSSr_65mm.**
 
-    n_bias: 3
-    n_dark: 3
-    exp_times_dark: 6
-    n_flat: 20
-    exp_times_flat: 3
-    script_mode: BIAS_DARK_FLAT
-    filter: SDSSz_65mm
-    grating: empty_1
+    .. code-block:: text
+      :caption: :file:`auxtel/make_latiss_calibrations.py`
 
+        n_flat: 20
+        exp_times_flat: 6
+        script_mode: BIAS_DARK_FLAT
+        filter: SDSSr_65mm
+        grating: empty_1
 
-4. **: Set configuration for SDSSy_65mm.**
+    2. **: Set configuration for SDSSg_65mm.**
 
-.. code-block:: text
-  :caption: :file:`auxtel/make_latiss_calibrations.py`
+    .. code-block:: text
+      :caption: :file:`auxtel/make_latiss_calibrations.py`
 
-    n_bias: 3
-    n_dark: 3
-    exp_times_dark: 6
-    n_flat: 20
-    exp_times_flat: 30
-    script_mode: BIAS_DARK_FLAT
-    filter: empty_1
-    grating: SDSSy_65mm
-
-5. **: Set configuration for empty_1.**
-
-.. code-block:: text
-  :caption: :file:`auxtel/make_latiss_calibrations.py`
-
-    n_bias: 3
-    n_dark: 3
-    exp_times_dark: 1
-    n_flat: 20
-    exp_times_flat: 1
-    script_mode: BIAS_DARK_FLAT
-    filter: empty_1
-    grating: empty_1
-
-6. **: Set sequence for the daily Photon Transfer Curve (PTC). Skip it if the previous sets were queued manually.**
-
-.. code-block:: text
-  :caption: :file:`auxtel/take_image_latiss.py`
-
-    image_type: FLAT
-    filter: SDSSr_65mm
-    grating: empty_1
-    reason: daily_PTC
-    exp_times:
-            0.25,
-            0.25,
-            1.42,
-            1.42,
-            6.53,
-            6.53,
-            4.23,
-            4.23,
-            30.04,
-            30.04,
-            12.56,
-            12.56,
-            57.75,
-            57.75,
-            8.13,
-            8.13,
-            2.73,
-            2.73,
-            3.40,
-            3.40,
-            1.77,
-            1.77,
-            111.03,
-            111.03,
-            37.35,
-            37.35,
-            0.48,
-            0.48,
-            0.59,
-            0.59,
-            10.10,
-            10.10,
-            1.14,
-            1.14,
-            0.20,
-            0.20,
-            89.29,
-            89.29,
-            71.81,
-            71.81,
-            0.38,
-            0.38,
-            0.31,
-            0.31,
-            19.43,
-            19.43,
-            2.20,
-            2.20,
-            15.62,
-            15.62,
-            0.92,
-            0.92,
-            0.74,
-            0.74,
-            24.16,
-            24.16,
-            5.25,
-            5.25,
-            46.44,
-            46.44
+        n_bias: 3
+        n_dark: 3
+        exp_times_dark: 6
+        n_flat: 20
+        exp_times_flat: 6
+        script_mode: BIAS_DARK_FLAT
+        filter: SDSSg_65mm
+        grating: empty_1
 
 
-7. **: Set sequence for daily_flats.**
+    3. **: Set configuration for SDSSz_65mm.**
 
-.. code-block:: text
-  :caption: :file:`auxtel/take_image_latiss.py`
+    .. code-block:: text
+      :caption: :file:`auxtel/make_latiss_calibrations.py`
 
-    image_type: FLAT
-    filter: SDSSr_65mm
-    grating: empty_1
-    reason: daily_sflat,
-    exp_times:
-                    0.5,
-                    0.5,
-                    0.5,
-                    0.5,
-                    0.5,
-                    12.8,
-                    12.8,
-                    12.8,
-                    12.8,
-                    12.8
+        n_bias: 3
+        n_dark: 3
+        exp_times_dark: 6
+        n_flat: 20
+        exp_times_flat: 3
+        script_mode: BIAS_DARK_FLAT
+        filter: SDSSz_65mm
+        grating: empty_1
 
 
-The BLOCK with :file:`latiss_daily_calibrations` configuration finishes with the :file:`auxtel/calibrations/power_off_atcalsys.py` SAL script with no configuration. It will turn off the lamp, close the shutter and shutdown the chiller. At this stage, the script completion time is 15 minutes.
+    4. **: Set configuration for SDSSy_65mm.**
 
-.. code-block:: text
-  :caption: :file:`auxtel/calibrations/power_off_atcalsys.py`
+    .. code-block:: text
+      :caption: :file:`auxtel/make_latiss_calibrations.py`
 
-Finally, the :file:`set_summary_state.py` script sends ATWhiteLight back to ``STANDBY``.
+        n_bias: 3
+        n_dark: 3
+        exp_times_dark: 6
+        n_flat: 20
+        exp_times_flat: 30
+        script_mode: BIAS_DARK_FLAT
+        filter: empty_1
+        grating: SDSSy_65mm
 
-.. code-block:: text
-  :caption: :file:`set_summary_state.py`
+    5. **: Set configuration for empty_1.**
 
-    data:
-   -
-     - ATWhiteLight
-     - STANDBY
+    .. code-block:: text
+      :caption: :file:`auxtel/make_latiss_calibrations.py`
 
-Once this last script is done, check the camera to make sure the white light is off. At this point, ATCS and LATISS are in ``ENABLED`` state and the dome and telescope are in FLAT position.
+        n_bias: 3
+        n_dark: 3
+        exp_times_dark: 1
+        n_flat: 20
+        exp_times_flat: 1
+        script_mode: BIAS_DARK_FLAT
+        filter: empty_1
+        grating: empty_1
+
+    6. **: Set sequence for the daily Photon Transfer Curve (PTC). Skip it if the previous sets were queued manually.**
+
+    .. code-block:: text
+      :caption: :file:`auxtel/take_image_latiss.py`
+
+        image_type: FLAT
+        filter: SDSSr_65mm
+        grating: empty_1
+        reason: daily_PTC
+        exp_times:
+                0.25,
+                0.25,
+                1.42,
+                1.42,
+                6.53,
+                6.53,
+                4.23,
+                4.23,
+                30.04,
+                30.04,
+                12.56,
+                12.56,
+                57.75,
+                57.75,
+                8.13,
+                8.13,
+                2.73,
+                2.73,
+                3.40,
+                3.40,
+                1.77,
+                1.77,
+                111.03,
+                111.03,
+                37.35,
+                37.35,
+                0.48,
+                0.48,
+                0.59,
+                0.59,
+                10.10,
+                10.10,
+                1.14,
+                1.14,
+                0.20,
+                0.20,
+                89.29,
+                89.29,
+                71.81,
+                71.81,
+                0.38,
+                0.38,
+                0.31,
+                0.31,
+                19.43,
+                19.43,
+                2.20,
+                2.20,
+                15.62,
+                15.62,
+                0.92,
+                0.92,
+                0.74,
+                0.74,
+                24.16,
+                24.16,
+                5.25,
+                5.25,
+                46.44,
+                46.44
+
+
+    7. **: Set sequence for daily_flats.**
+
+    .. code-block:: text
+      :caption: :file:`auxtel/take_image_latiss.py`
+
+        image_type: FLAT
+        filter: SDSSr_65mm
+        grating: empty_1
+        reason: daily_sflat,
+        exp_times:
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.5,
+                        12.8,
+                        12.8,
+                        12.8,
+                        12.8,
+                        12.8
+
+
+#. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
+
+    .. code-block:: text
+      :caption: :file:`add_block.py`
+
+      id: shutdown_latiss_calibrations
+
+
+    The BLOCK with :file:`shutdown_latiss_calibrations` configuration finishes with the :file:`auxtel/calibrations/power_off_atcalsys.py` SAL script with no configuration. It will turn off the lamp, close the shutter and shutdown the chiller. At this stage, the script completion time is 15 minutes.
+
+    .. code-block:: text
+      :caption: :file:`auxtel/calibrations/power_off_atcalsys.py`
+
+    Finally, the :file:`set_summary_state.py` script sends ATWhiteLight back to ``STANDBY``.
+
+    .. code-block:: text
+      :caption: :file:`set_summary_state.py`
+
+        data:
+          -
+           - ATWhiteLight
+           - STANDBY
+
+Once the last script is done, check the camera to make sure the white light is off. At this point, ATCS and LATISS are in ``ENABLED`` state and the dome and telescope are in FLAT position.
 
 .. note::
    The location of the `BLOCK source code`_ can be checked and if the filters or exposures times have changed, create a ticket for yourself and edit this document accordingly.
 
 
 .. _Daytime-Operations-LATISS-Daily-Calibrations-BIAS-DARK-FLAT-all-filters-empty-Contingency:
+
 Contingency
 ===========
 In cases such as telescope and dome movement not allowed or not cleared, or not enough time available for calibrations, skip this procedure.

--- a/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.rst
@@ -43,7 +43,7 @@ Procedure Steps
 #. Calibrations images should only be taken if the LATISS WREB temperature is under temperature control. Check the LATISS WREB temperatures under the `AuxTel (LATISS) Temperatures and Pressures dashboard`_ in Chronograf. WREB temperatures are visible in the lower middle panel labeled *WREB On Board*. If the *mean_temp2* (top blue line) is between 26-29 degress C, the temperature is suitable for taking calibrations. During the daytime, the fan on the WREB board may not be sufficient to cool the WREB down to these temperatures, so during warmer months you may have to wait until later in the day or early in the morning for it to reach the desired temperature. If the temperature is too high, do not proceed to the next steps.
 #. Enable ATCS and LATISS using the standard scripts :file:`enable_atcs.py` and :file:`enable_latiss.py` with no configuration. 
 #. Enable ``Scheduler:2`` with a valid scheduler configuration. Use the standard script :file:`auxtel/scheduler/enable.py` with the configuration required for the run and available in the corresponding night log. 
-#. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
+#. **Setup LATISS calibrations** BLOCK will setup ATCS and white light for calibrations. It enables and turns on the ATWhiteLight, enables OCPS:1 and commands AuxTel mount and dome to the FLAT position. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
 
     .. code-block:: text
       :caption: :file:`add_block.py`
@@ -80,8 +80,9 @@ Procedure Steps
     .. code-block:: text
       :caption: :file:`auxtel/prepare_for/flat.py`
   
+    .. Note: We need to document and link here how to access the aux-cam01/02cameras.
 
-#. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
+#. The **LATISS daily calibrations** BLOCK will queue the scripts focused on the calibration image adquisition. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
 
     .. code-block:: text
       :caption: :file:`add_block.py`
@@ -89,7 +90,7 @@ Procedure Steps
       id: latiss_daily_calibrations
 
 
-    The BLOCK with :file:`latiss_daily_calibrations` configuration will queue the scripts focused on the calibration image adquisition. Depending on which filters are currently installed in LATISS, the :file:`auxtel/make_latiss_calibrations.py` script may take different calibration sets. The calibration images displayed in `RubinTV`_ are post-ISR images and should have BIAS and DARK corrections applied. This means that BIAS and DARK images should display with maximum count rates of about 10 ADUs. In the case of FLAT images, counts must be below the :math:`\approx` 30000 ADUs. In the process of building the daily PTC (see below), the FLAT saturation is intended, and achieved at around the 123000 ADUs (with exposure time of about 25 seconds). In case daily FLATS are taken, they reach values of :math:`\approx` 68000 ADUs. If you see large deviations from these values, which can be related with a problem in the instrument signature removal in `RubinTV`_, then RAW count rates are being displayed, please report it. Check the calibration sets and their configurations for each filter installed and the grating.
+    Depending on which filters are currently installed in LATISS, the :file:`auxtel/make_latiss_calibrations.py` script may take different calibration sets. The calibration images displayed in `RubinTV`_ are post-ISR images and should have BIAS and DARK corrections applied. This means that BIAS and DARK images should display with maximum count rates of about 10 ADUs. In the case of FLAT images, counts must be below the :math:`\approx` 30000 ADUs. In the process of building the daily PTC (see below), the FLAT saturation is intended, and achieved at around the 123000 ADUs (with exposure time of about 25 seconds). In case daily FLATS are taken, they reach values of :math:`\approx` 68000 ADUs. If you see large deviations from these values, which can be related with a problem in the instrument signature removal in `RubinTV`_, then RAW count rates are being displayed, please report it. Check the calibration sets and their configurations for each filter installed and the grating.
 
     1. **: Set configuration for SDSSr_65mm.**
 
@@ -254,7 +255,7 @@ Procedure Steps
                         12.8
 
 
-#. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
+#. The **Shutdown LATISS calibrations** BLOCK will turn off the calibration lamp and leave it on standby state. Run the script :file:`add_block.py` to the ATQueue  with the following configuration:
 
     .. code-block:: text
       :caption: :file:`add_block.py`


### PR DESCRIPTION
Hi Erik,
I did a quick update on the LATISS calibrations documentation including the split (thanks!) that you formulated on the original `latiss_daily_calibration` BLOCK. I followed the corresponding .json files to match the document description. 

[The html version of the document can be read here.](https://obs-ops.lsst.io/v/SITCOM-1465/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.html)

Thank you in advance,
Karla Peña.