### PR TITLE
Update documentation for tickets/SITCOM-1793

### DIFF
--- a/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.rst
@@ -26,7 +26,8 @@ This procedure will enable and turn on the ATWhiteLight that illuminates the dom
 This page assumes the reader is familiar with the content explained in the Observatory section: :ref:`Introduction to the combined calibrations generation procedure <Introduction-Combined-Calibrations-Generation-index>` 
 
 .. warning::
-  This procedure involves telescope motion with AuxTel. Be sure to confirm the dome is clear of personnel and announce that you are going to run the calibrations with telescope movement on the *#summit-announce* and *#summit-auxtel* channels before you run the following steps. The whole process takes about 1.5 hours.
+  This procedure involves telescope motion with AuxTel. Be sure to confirm the dome is clear of personnel and announce that you are going to run the calibrations with telescope movement on the *#summit-announce* and *#summit-auxtel* channels before you run the following steps. The Daytime calibrations can be taken at any time or under any conditions when convenient and they do not include the use of the Electrometer, Monochromator, or FiberSpectrograph CSCs, these can remain in ``STANDBY`` while running. 
+
 
 
 .. _Daytime-Operations-LATISS-Daily-Calibrations-BIAS-DARK-FLAT-all-filters-empty-Post-Conditions:
@@ -89,7 +90,7 @@ Procedure Steps
       id: BLOCK-295
 
 
-    Depending on which filters are currently installed in LATISS, the :file:`auxtel/make_latiss_calibrations.py` script may take different calibration sets. The calibration images displayed in `RubinTV`_ are post-ISR images and should have BIAS and DARK corrections applied. This means that BIAS and DARK images should display with maximum count rates of about 10 ADUs. In the case of FLAT images, counts must be below the :math:`\approx` 30000 ADUs. In the process of building the daily PTC (see below), the FLAT saturation is intended, and achieved at around the 123000 ADUs (with exposure time of about 25 seconds). In case daily FLATS are taken, they reach values of :math:`\approx` 68000 ADUs. If you see large deviations from these values, which can be related with a problem in the instrument signature removal in `RubinTV`_, then RAW count rates are being displayed, please report it. Check the calibration sets and their configurations for each filter installed and the grating.
+    Depending on which filters are currently installed in LATISS, the :file:`auxtel/make_latiss_calibrations.py` script may take different calibration sets. The calibration images displayed in `RubinTV`_ are post-ISR images and should have BIAS and DARK corrections applied. This means that BIAS and DARK images should display with maximum count rates of about 10 ADUs. In the case of FLAT images, counts must be below the :math:`\approx` 30000 ADUs. In the process of building the daily PTC (see below), the FLAT saturation is intended, and achieved at around the 123000 ADUs (with exposure time of about 25 seconds). In case daily FLATS are taken, they reach values of :math:`\approx` 68000 ADUs. If you see large deviations from these values, which can be related with a problem in the instrument signature removal in `RubinTV`_, then RAW count rates are being displayed, please report it. The calibration sets and their configurations can change depending on specific requirements (e.g. usage of filters BG40, OG550). Below it is listed the regular configuration sets.
 
     1. **: Set configuration for SDSSr_65mm.**
 

--- a/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-only-procedure.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-only-procedure.rst
@@ -17,11 +17,12 @@ LATISS Daily Calibrations BIAS and DARK only
 .. _Daytime-Operations-LATISS-Daily-Calibrations-BIAS-DARK-only-Overview:
 Overview
 ========
-This procedure will acquire BIAS and DARK calibration images. 
+This procedure will acquire BIAS and DARK calibration images only. 
 This page assumes the reader is familiar with the content explained in the Observatory section: :ref:`Introduction to the combined calibrations generation procedure.<Introduction-Combined-Calibrations-Generation-index>` 
 
 .. warning::
   This procedure does not involves telescope motion with AuxTel. Announce that you are about to run the calibrations without telescope or dome movement on the *#summit-announce* and *#summit-auxtel* channels before you run the following steps.
+  The Daytime calibrations can be taken at any time or under any conditions when convenient and they do not include the use of the Electrometer, Monochromator, or FiberSpectrograph CSCs, these can remain in ``STANDBY`` while running.  
 
 .. _Daytime-Operations-LATISS-Daily-Calibrations-BIAS-DARK-only-Post-Conditions:
 Post-Condition
@@ -32,16 +33,6 @@ Post-Condition
 .. _Daytime-Operations-LATISS-Daily-Calibrations-BIAS-DARK-only-Procedure-Steps:
 Procedure Steps
 ===============
-
-#. Calibration images should only be taken if the LATISS WREB temperature is under temperature control.
-    
-    Check the LATISS WREB temperatures under the `AuxTel (LATISS) Temperatures and Pressures dashboard`_ in Chronograf. WREB temperatures are visible in the lower middle panel labeled *WREB On Board*. 
-        
-    If the *mean_temp2* (top blue line) is between 26-29 degress C, the temperature is suitable for taking calibrations. 
-        
-    During the daytime, the fan on the WREB board may not be sufficient to cool the WREB down to these temperatures, so during warmer months you may have to wait until later in the day or early in the morning for it to reach the desired temperature. 
-        
-    If the temperature is too high, do not proceed to the next steps. 
 
 #. Enable ATCS and LATISS using the standard scripts :file:`enable_atcs.py` and :file:`enable_latiss.py` with no configuration. 
 #. Enable the OCPS:1 CSC which is used to run automatic verification pipelines on the data. The :file:`set_summary_state.py` script will enable the ``OCPS:1`` CSC.


### PR DESCRIPTION
Hi Paulo,
I already include the changes required in the [ticket](https://rubinobs.atlassian.net/browse/SITCOM-1793) for this document. The filter changes text were left as general as possible since the current configuration is just temporal. Let me know if you have any comments.

The rendered pages can be found [here](https://obs-ops.lsst.io/v/SITCOM-1793/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-FLAT-all-filters-empty-procedure.html) and [here](https://obs-ops.lsst.io/v/SITCOM-1793/AuxTel/Standard-Operations/Daytime-Operations/latiss-daily-calibrations-BIAS-DARK-only-procedure.html).

Thank you for your time.
