### PR TITLE
Tickets/SITCOM-1945

### DIFF
--- a/Observing-Constraints/AuxTel/index.rst
+++ b/Observing-Constraints/AuxTel/index.rst
@@ -131,7 +131,7 @@ Wind speeds greater than 15 m/s (measured over the last 10 data points):
 .. warning::
     Dome drop-down shutter:
         The AuxTel dome shutter has a drop-down shutter that opens like a flap, causing it to extend further past the dome structure. 
-        It is opened when observing targets below 25 degrees elevation. 
+        It is opened when observing targets below 28 degrees elevation. 
         The drop-down shutter is susceptible to wind gusts, and should be closed if gusts reach over 8 m/s.
 
 .. _auxtel-weather-constraints-humidity-and-dew-point:


### PR DESCRIPTION
I updated the dome drop-out shutter elevation criteria in AuxTel weather constraints from 25 degrees to 28 degrees. Take a look and let me know when I can merge this ticket.