### PR TITLE
Changed latiss calibration script from maintel to auxtel.

### DIFF
--- a/AuxTel/Standard-Operations/Daytime-Operations/latiss-combined-calibrations-procedure.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/latiss-combined-calibrations-procedure.rst
@@ -45,7 +45,7 @@ Once you are logged into LOVE, click on the ``ATQueue`` panel, as circled on the
 Load the Script
 ---------------
 
-After clicking on the ``ATQueue`` panel, search for the script ``maintel/make_latiss_calibrations.py`` under ``AVAILABLE SCRIPTS`` on the left, as shown in the figure below:
+After clicking on the ``ATQueue`` panel, search for the script ``auxtel/make_latiss_calibrations.py`` under ``AVAILABLE SCRIPTS`` on the left, as shown in the figure below:
 
 .. figure:: ./_static/love-available-scripts.png
     :name: available-scripts-love


### PR DESCRIPTION
Hi @PaulinaLSST I updated the LATISS Combined Calibrations Generation Procedure page to say auxtel/make_latiss_calibrations.py in the script configuration rather than maintel/make_latiss_calibrations.py. As soon as you approve the pull request I will merge the update. Thank you!