### PR TITLE
Tickets/SITCOM-1941

### DIFF
--- a/AuxTel/SAL-Scripts/ATCommonSALScripts.rst
+++ b/AuxTel/SAL-Scripts/ATCommonSALScripts.rst
@@ -242,6 +242,23 @@ ATCS
        | ``auxtel/standby_atcs.py``
        | `ts_standardscripts/data/scripts/auxtel/standby_atcs.py <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/data/scripts/auxtel/standby_atcs.py>`_
      - No configurations
+   * - 
+     - Apply offsets to the ATCS
+     - | ``auxtel/offset_atcs.py``
+       | `ts_standardscripts/data/scripts/auxtel/offset_atcs.py <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/data/scripts/auxtel/offset_atcs.py>`_
+     - 
+       .. dropdown:: SAL Script
+
+         To fully clear offsets affected by a pointing error:
+
+         .. code-block:: text
+
+           reset_offsets:
+             reset_absorbed: true
+             reset_non_absorbed: true
+           
+         **NOTE:** This will reset all of the offsets, including those added by the ``correct_pointing.py`` script.
+
    * - **ATMCS**
      - AT change Nasmyth to port 1
      - | ``run_command.py``

--- a/AuxTel/Troubleshooting/ATCS/ATDome-Fails-to-Arrive-In-Position.rst
+++ b/AuxTel/Troubleshooting/ATCS/ATDome-Fails-to-Arrive-In-Position.rst
@@ -155,7 +155,27 @@ Procedure Steps
       This script will make sure the system is back and ready for observations, 
       with the mirror cover and dome shutter opened as well as the dome following enabled.
 
-3. Keep ATQueue running to the next target. Confirm in LOVE that the dome is moving and following the mount.
+.. note::
+
+    There are times where a pointing problem may occur because while AuxTel attempts to center on a star,
+    it may, instead, **center on a defect.** This problem happens more likely when one needs to apply an offset
+    using the ``offset_atcs.py`` script. Should this occur, the steps to recover are as follows:
+
+    1. Rerun ``offset_atcs.py`` in the ScriptQueue with the following configuration:
+      
+    .. code-block:: text
+    
+        reset_offsets:
+            reset_absorbed: true
+            reset_non_absorbed: true
+
+    2. Run ``correct_pointing.py`` script again with a new azimuth and elevation.
+
+    Additional configuration parameters for ``offset_atcs.py`` can be found on the
+    `Common AuxTel Scripts & Configurations <https://obs-ops.lsst.io/AuxTel/SAL-Scripts/ATCommonSALScripts.html>`_
+    page.
+
+1. Keep ATQueue running to the next target. Confirm in LOVE that the dome is moving and following the mount.
 
 Post-Condition
 ==============


### PR DESCRIPTION
Hey Paulina and Erik,

I updated the "ATDome Fails to Arrive in Position" to include a note about recovering ATCS offsets when AuxTel points to a defect instead of the star. Take a look and please provide comments. I also added offset_atcs.py script into the Common SAL Scripts page, so please let me know if there are any additional configurations I should add for observers to know. Thank you!

- Kris