### PR TITLE
tickets/SITCOM-2310

### DIFF
--- a/AuxTel/Non-Standard-Operations/ATCS/Vent-Gate-Extraction-Fan-Operation.rst
+++ b/AuxTel/Non-Standard-Operations/ATCS/Vent-Gate-Extraction-Fan-Operation.rst
@@ -1,0 +1,282 @@
+.. This is a template for operational procedures. Each procedure will have its own sub-directory. This comment may be deleted when the template is copied to the destination.
+
+.. Review the README in this procedure's directory on instructions to contribute.
+.. Static objects, such as figures, should be stored in the _static directory. Review the _static/README in this procedure's directory on instructions to contribute.
+.. Do not remove the comments that describe each section. They are included to provide guidance to contributors.
+.. Do not remove other content provided in the templates, such as a section. Instead, comment out the content and include comments to explain the situation. For example:
+	- If a section within the template is not needed, comment out the section title and label reference. Include a comment explaining why this is not required.
+    - If a file cannot include a title (surrounded by ampersands (#)), comment out the title from the template and include a comment explaining why this is implemented (in addition to applying the ``title`` directive).
+
+.. Include one Primary Author and list of Contributors (comma separated) between the asterisks (*):
+.. |author| replace:: *Kris Mortensen*
+.. If there are no contributors, write "none" between the asterisks. Do not remove the substitution.
+.. |contributors| replace:: *OS Team*
+
+.. This is the label that can be used as for cross referencing this procedure.
+.. Recommended format is "Directory Name"-"Title Name"  -- Spaces should be replaced by hyphens.
+.. _Vent-Gate-Extraction-Fan-Operation:
+
+######################################
+Vent Gate and Extraction Fan Operation
+######################################
+
+.. _Vent-Gate-Extraction-Fan-Operation-Overview:
+
+Overview
+========
+
+This procedure describes how to operate the AuxTel vent gate and extractor fan—both remotely via the ATBuilding CSC 
+and, when needed, using local manual controls—to ventilate the AuxTel enclosure in preparation for and during on‑sky operations. 
+
+By opening Vent Gate 3 and running the extraction fan within defined wind and humidity limits, 
+observers can flush warm, stagnant, or moist air from the enclosure and promote a more stable internal environment, 
+reducing dome seeing and thermal gradients that degrade image quality.
+
+.. admonition:: Weather Constraints
+    :class: warning
+
+    Operation of the vent gate is dependent on the :ref:`AuxTel weather constraints <Observing-Constraints-AuxTel-Weather-Constraints>`. 
+    In general, only operate the vent gate when:
+
+    *  Wind speeds are :math:`< 10` m/s.
+    *  Relative humidity is :math:`< 70\%`.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Precondition:
+
+Precondition
+============
+
+-  Before taking the decision to open the vent gate, review the weather conditions and :ref:`weather constraints <Observing-Constraints-AuxTel-Weather-Constraints>` page.
+
+-  AuxTel is fully ready to operate and all components are enabled. 
+
+-  The :ref:`daytime checkout <AuxTel-DayTime-Operations-Daytime-Checkout>` has been executed successfully. 
+
+-  Observers will begin :ref:`venting AuxTel <AuxTel-Daytime-Operations-Prepare-for-vent>` or  
+   :ref:`on-sky preparations <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`, 
+   but non-standard operation of the vent gate and extration fan is required:
+
+   -  ``auxtel/prepare_for/vent.py`` or ``auxtel/prepare_for/onsky.py`` fail to automatically open/close 
+      the vent gate and turn on/off the extraction fan.
+   -  Weather conditions change, and require manual override of the vent gate and/or extraction fan.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Post-Condition:
+
+Post-Condition
+==============
+
+- If venting AuxTel, vent gate is open and extraction fan is on. 
+- If preparing on-sky operations, vent gate is closed and extraction fan is off.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Procedure-Steps:
+
+Procedure Steps
+===============
+
+.. note::
+
+    Monitor each step in the procedure using the 
+    `ATBuilding Chronograf Dashboard <https://summit-lsp.lsst.codes/chronograf/sources/1/dashboards/462?refresh=Paused&lower=now%28%29%20-%2015m>`_.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Activate:
+
+Activate Vent Gate and Extraction Fan
+*************************************
+
+This section outlines the steps required to open AuxTel's vent gate and power on the extraction fan.
+This procedure is for when AuxTel has begun its :ref:`venting procedures <AuxTel-Daytime-Operations-Prepare-for-vent>`.
+
+.. _Vent-Gate-Extraction-Fan-Operation-CSC-Control:
+
+Set CSC Control
+---------------
+
+1.  Verify that ATBuilding CSC is ``ENABLED``. If not, enable it using either LOVE's 
+    `ASummaryState <https://summit-lsp.lsst.codes/love/uif/view?id=51>`_
+    or with the :file:`set_summary_state.py` script in 
+    `ATQueue <https://summit-lsp.lsst.codes/love/uif/view?id=41>`_.
+
+    .. code-block:: python
+        :caption: set_summary_state.py
+
+        data:
+            - [ATBuilding, ENABLED]
+
+2.  Change control of ATBuilding from *Manual* to *CSC* using the :file:`run_command.py` script
+    with the following configuration:
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanManualControlMode
+        parameters:
+           enableManualControlMode: False
+    
+    Check on Chronograph that the ``Extraction Fan Control Mode`` is now set to ``CSC``.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Prepare-Venting:
+
+Prepare for Venting
+-------------------
+
+1.  Open Vent Gate 3, and confirm on Chronograf that the vent gate state
+    transitions from ``CLOSED`` to ``PARTIALLY_OPEN``.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: openVentGate
+        parameters:
+           gate: [2, -1, -1, -1]
+
+    .. note::
+
+        The array consists of four elements, corresponding to the four vent gates. 
+        To operate a specific gate, add its ID 
+        (gate IDs are numbered from 0-3, counter-clockwise from the front entrance door). 
+        If no gate operation is needed, use -1 as a placeholder.
+
+2.  Turn on the extraction fan at Vent Gate 3, and set the target frequency to 20Hz.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanDriveFreq
+        parameters:
+           targetFrequency: 20
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Deactivate:
+
+Deactivate Vent Gate and Extraction Fan
+***************************************
+
+This section outlines the steps required to close AuxTel's vent gate and power off the extraction fan.
+This procedure is for when AuxTel has begun its :ref:`on-sky procedures <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Stop-Venting:
+
+Stop Venting
+------------
+
+1.  Turn of the extraction fan at Vent Gate 3 by setting the target frequency to 0Hz.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanDriveFreq
+        parameters:
+           targetFrequency: 0
+
+2.  Close Vent Gate 3, and confirm on Chronograf that the vent gate state
+    transitions from ``PARTIALLY_OPEN`` to ``CLOSED``.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: closeVentGate
+        parameters:
+           gate: [2, -1, -1, -1]
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Manual-Control:
+
+Set Manual Control
+------------------
+
+1.  Change control of ATBuilding from *CSC* to *Manual* using the :file:`run_command.py` script
+    with the following configuration:
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanManualControlMode
+        parameters:
+           enableManualControlMode: False
+    
+    Check on Chronograph that the ``Extraction Fan Control Mode`` is now set to ``Manual``.
+
+2.  Set the ATBuilding CSC to ``STANDBY`` using either LOVE's 
+    `ASummaryState <https://summit-lsp.lsst.codes/love/uif/view?id=51>`_
+    or with the :file:`set_summary_state.py` script in 
+    `ATQueue <https://summit-lsp.lsst.codes/love/uif/view?id=41>`_ .
+
+    .. code-block:: python
+        :caption: set_summary_state.py
+
+        data:
+            - [ATBuilding, STANDBY]
+
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Troubleshooting:
+
+Troubleshooting
+===============
+
+.. _Vent-Gate-Extraction-Fan-Operation-Troubleshooting-Raspberry-Pi:
+
+Raspberry Pi Rebooting
+----------------------
+
+If any of the following issues occur:
+
+-  Inability to transition ATBuilding CSC to enable
+-  Commands are not producing the expected results
+-  Interruption in ATBuilding telemetry
+-  ATBuilding CSC enters FAULT mode
+
+Then the solution will be to restart the Raspberry Pi software on the AuxTel vent gate.
+
+1.  Using a command line, open a secure shell to the host :command:`auxtel-vent-gates01.cp.lsst.org` and
+    :command:`reboot` the Raspberry Pi.
+
+    .. code-block:: bash
+        
+        >> ssh auxtel-vent-gates01.cp.lsst.org
+        >> reboot
+
+2.  If the :command:`reboot` command does not work, restart the :command:`vent_controller` container.
+
+    .. code-block:: bash
+
+        >> ssh auxtel-vent-gates01.cp.lsst.org
+        >> docker run -d --restart unless-stopped --name vent_controller --device /dev/i2c-1 \
+              -p 0.0.0.0:17311:23 --user root \
+              lsstts/vents-controller-aarch64:k0003.001 --modbus-host auxtel-vent-fan01.cp.lsst.org
+
+3. If neither of the previous steps were successful, contact support on `#summit-auxtel <https://rubin-obs.slack.com/archives/C07Q45NUK4P>`_
+   for help on manually power cycling the Raspberry Pi.
+
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Troubleshooting-Manual-Operation:
+
+Vent Gate Manual Operation
+--------------------------
+
+In the case of an emergency, when remote connection of the vent gate is not possible, 
+observers may have to manually operate the vent gate and extraction fan to allow venting procedures to continue.
+
+1.  Verify and the vent gate controls are set to *Manual*. If not, follow instructions in the 
+    :ref:`Vent-Gate-Extraction-Fan-Operation-Manual-Control` section of this procedure.
+2.  Head to calibration hill, and locate Vent Gate 3 inside of the AuxTel dome. 
+    The vent gate is opposite of the main entrance on level 1.
+3.  Locate the vent gate control switch to the left of the vent gate (on the wall)
+    and the extraction fan controller to the right of the vent gate (see image below).
+
+    a.  If starting venting procedures, set the vent gate switch to ``OPEN``, and 
+        rotate the extraction dial clockwise until is reads **20Hz**.
+    b.  If stopping venting procedures, rotate the extraction dial counter-clockwise 
+        until is reads **0Hz**, and set the vent gate switch to ``CLOSED``.
+
+.. figure:: /AuxTel/Standard-Operations/Daytime-Operations/_static/PrepareforVent_AuxTel_VentGate3andFan.png
+      :name: Dome Vent Gate 3 and Extraction Fan 
+
+      AuxTel Dome Vent Gate 3 and Extraction Fan with Controller.

--- a/AuxTel/Standard-Operations/Daytime-Operations/Prepare-for-Vent.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/Prepare-for-Vent.rst
@@ -72,6 +72,9 @@ Procedure Steps
 
 #. Announce in the #summit-announce and #summit-auxtel Slack channel that AuxTel is going to vent, and telescope and dome will move. 
 
+#. If the wind speed is below 10 m/s, navigate to the :ref:`Vent-Gate-Extraction-Fan-Operation-Activate` procedure, and
+   follow the instructions to open vent gate #3 and power on the extraction fan to 20Hz.
+
 #. Command the telescope and dome to prepare for venting. 
 
    Load the ``auxtel/prepare_for/vent.py`` script from the LOVE ``ATQueue`` panel, under ``AVAILABLE SCRIPTS`` by clicking on the blue icon. 
@@ -109,14 +112,6 @@ Procedure Steps
      :name: script prepareforonsky_AuxTel running
 
      ``auxtel/prepare_for/vent.py`` script running until observer manually stops it or the Sun reaches 5 deg above horizon. 
-
-#. If the wind speed is below 10 m/s, manually open **only** vent gate #3 using the switch and turn on the extraction fan to **20-25Hz**. 
-   If wind speed is above or close to 10 m/s, keep vent gates closed and extraction fan off. 
-
-   .. figure:: ./_static/PrepareforVent_AuxTel_VentGate3andFan.png
-      :name: Dome Vent Gate 3 and Extraction Fan 
-
-      AuxTel dome vent gate #3 and extraction fan with its controller located at the dome pier. 
 
 #. Visually confirm in `LOVE displays <http://love01.cp.lsst.org/uif/view?id=68>`__ that the system is venting. 
         

--- a/AuxTel/Standard-Operations/Daytime-Operations/Prepare-for-Vent.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/Prepare-for-Vent.rst
@@ -8,7 +8,7 @@
 .. Include one Primary Author and list of Contributors (comma separated) between the asterisks (*):
 .. |author| replace:: *isotuela*
 .. If there are no contributors, write "none" between the asterisks. Do not remove the substitution.
-.. |contributors| replace:: *Kristopher Mortensen, Kate Napier, Alysha Shugart*
+.. |contributors| replace:: *Kristopher Mortensen, Kate Napier, Alysha Shugart, Erik Dennihy*
 
 .. This is the label that can be used as for cross referencing this procedure.
 .. Recommended format is "Directory Name"-"Title Name"  -- Spaces should be replaced by hyphens.
@@ -19,7 +19,7 @@
 .. An error will alert you of identical labels during the build process.
 
 ################
-Prepare for vent
+Prepare for Vent
 ################
 
 .. _Prepare-for-vent-Overview:
@@ -35,7 +35,7 @@ This way, the local thermal imbalances in the air inside the dome, that could de
 In a typical observing night, observers must start venting in the afternoon following the execution of :ref:`daytime checkout <AuxTel-DayTime-Operations-Daytime-Checkout>` and 
 :ref:`calibrations <AuxTel-Daytime-Operations-LATISS-Combined-Calibrations-Generation-Procedure>`, when applicable.  
 
-Once the Sun's elevation above horizon is below 25 degrees, please proceed to :ref:`prepare for on-sky operations <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`. 
+Once the Sun's elevation above horizon drops below 25 degrees, please proceed to :ref:`prepare for on-sky operations <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`. 
 The Sun's coordinates at any given time, along with several other useful ephemeris, can be found at the :ref:`sky almanac <Visualization-and-Monitoring-Tools-Sky-Almanac>`.
 
 .. _Prepare-for-vent-Precondition:
@@ -58,11 +58,9 @@ Precondition
 Post-Condition
 ==============
 
-- Telescope is venting. 
-
-  The ``auxtel/prepare_for/vent.py`` script will run until the Sun's elevation is 5 degrees above the horizon, if there's no operator interaction prior to that. 
+- Telescope is venting. The ``auxtel/prepare_for/vent.py`` script will run until the Sun's elevation is 0 degrees above the horizon, if there's no operator interaction prior to that. 
   
-  Once the Sun's elevation is past below 25 degrees above horizon, please :ref:`prepare for on-sky operations <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`. 
+- Once the Sun's elevation is less than 25 degrees above the horizon, please :ref:`prepare for on-sky operations <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`. 
 
 .. _Prepare-for-vent-Procedure-Steps:
 
@@ -100,6 +98,10 @@ Procedure Steps
        * Disable AOS open loop corrections. 
        * Slew dome to face opposite the Sun; az = Sun's azimuth - 180 deg.
        * Partially opens the dome to allow consistent air flow.
+       * Check the average wind speed over the last 10 minutes.
+       * If the average wind speed is below 10 m/s, open Vent Gate 3 and turn the extraction fan on to 20% speed.
+       * Continuously monitor the wind speed. If it exceeds 10 m/s, it will close the vent gate and turn of the extraction fan.
+       * When the script is terminated or completes, it will turn the extraction fan off and close the vent gate.
 
    .. note::
      The ``auxtel/prepare_for/vent.py`` script will keep running until the Sun's elevation is 0 degrees above the horizon, 
@@ -108,15 +110,21 @@ Procedure Steps
    .. figure:: ./_static/PrepareforVent_AuxTel_running.png
      :name: script prepareforonsky_AuxTel running
 
-     ``auxtel/prepare_for/vent.py`` script running until observer manually stops it or the Sun reaches 5 deg above horizon. 
+     ``auxtel/prepare_for/vent.py`` script running until observer manually stops it or the Sun reaches 0 deg above horizon. 
 
-#. If the wind speed is below 10 m/s, manually open **only** vent gate #3 using the switch and turn on the extraction fan to **20-25Hz**. 
-   If wind speed is above or close to 10 m/s, keep vent gates closed and extraction fan off. 
+#. Monitor the state of the Vent Gate 3 and its extraction fault using the 
+   `ATBuilding Chronograf Dashboard <https://summit-lsp.lsst.codes/chronograf/sources/1/dashboards/462?refresh=Paused&lower=now%28%29%20-%2024h>`_.
 
-   .. figure:: ./_static/PrepareforVent_AuxTel_VentGate3andFan.png
-      :name: Dome Vent Gate 3 and Extraction Fan 
+   - If the average wind speed is **below 10 m/s**, the script will automatically open the vent gate and turn on the extraction fan to 20%. 
+   - If the average wind speed is **above 10 m/s**, the script will NOT open vent gates closed or turn the extraction fan on.
+   - If the average wind speed **exceeds 10 m/s** *while the script is running*, it will turn the extraction fan off and close the vent gate. 
+     The script will *NOT* attempt to re-open them.
 
-      AuxTel dome vent gate #3 and extraction fan with its controller located at the dome pier. 
+   .. note::
+
+    Should observers need to override the current state of Vent Gate 3 and its extraction fan, 
+    navigate to the :ref:`Vent-Gate-Extraction-Fan-Operation-Activate` procedure.
+    The page provides non-standard instructions to open/close Vent Gate 3 and power on/off the extraction fan.
 
 #. Visually confirm in `LOVE displays <http://love01.cp.lsst.org/uif/view?id=68>`__ that the system is venting. 
         

--- a/AuxTel/Standard-Operations/Daytime-Operations/Vent-Gate-Extraction-Fan-Operation.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/Vent-Gate-Extraction-Fan-Operation.rst
@@ -1,0 +1,204 @@
+.. This is a template for operational procedures. Each procedure will have its own sub-directory. This comment may be deleted when the template is copied to the destination.
+
+.. Review the README in this procedure's directory on instructions to contribute.
+.. Static objects, such as figures, should be stored in the _static directory. Review the _static/README in this procedure's directory on instructions to contribute.
+.. Do not remove the comments that describe each section. They are included to provide guidance to contributors.
+.. Do not remove other content provided in the templates, such as a section. Instead, comment out the content and include comments to explain the situation. For example:
+	- If a section within the template is not needed, comment out the section title and label reference. Include a comment explaining why this is not required.
+    - If a file cannot include a title (surrounded by ampersands (#)), comment out the title from the template and include a comment explaining why this is implemented (in addition to applying the ``title`` directive).
+
+.. Include one Primary Author and list of Contributors (comma separated) between the asterisks (*):
+.. |author| replace:: *Kris Mortensen*
+.. If there are no contributors, write "none" between the asterisks. Do not remove the substitution.
+.. |contributors| replace:: *OS Team*
+
+.. This is the label that can be used as for cross referencing this procedure.
+.. Recommended format is "Directory Name"-"Title Name"  -- Spaces should be replaced by hyphens.
+.. _Vent-Gate-Extraction-Fan-Operation:
+
+######################################
+Vent Gate and Extraction Fan Operation
+######################################
+
+.. _Vent-Gate-Extraction-Fan-Operation-Overview:
+
+Overview
+========
+
+This procedure describes how to operate the AuxTel vent gate and extractor fan—both remotely via the ATBuilding CSC 
+and, when needed, using local manual controls—to ventilate the AuxTel enclosure in preparation for and during on‑sky operations. 
+
+By opening vent gate #3 and running the extraction fan within defined wind and humidity limits, 
+observers can flush warm, stagnant, or moist air from the enclosure and promote a more stable internal environment, 
+reducing dome seeing and thermal gradients that degrade image quality.
+
+.. admonition:: Weather Constraints
+    :class: warning
+
+    Operation of the vent gate is dependent on the :ref:`AuxTel weather constraints <Observing-Constraints-AuxTel-Weather-Constraints>`. 
+    In general, only operate the vent gate when:
+
+    *  Wind speeds are :math:`< 10` m/s.
+    *  Relative humidity is :math:`< 70\%`.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Precondition:
+
+Precondition
+============
+
+-  Before taking the decision to open the vent gate, review the weather conditions and :ref:`weather constraints <Observing-Constraints-AuxTel-Weather-Constraints>` page.
+
+-  AuxTel is fully ready to operate and all components are enabled. 
+
+-  The :ref:`daytime checkout <AuxTel-DayTime-Operations-Daytime-Checkout>` has been executed successfully. 
+
+-  Observers will begin :ref:`venting AuxTel <AuxTel-Daytime-Operations-Prepare-for-vent>` or  
+   :ref:`on-sky preparations <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Post-Condition:
+
+Post-Condition
+==============
+
+- If venting AuxTel, vent gate is open and extraction fan is on. 
+- If preparing on-sky operations, vent gate is closed and extraction fan is off.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Procedure-Steps:
+
+Procedure Steps
+===============
+
+.. note::
+
+    Monitor each step in the procedure using the 
+    `ATBuilding Chronograf Dashboard <https://summit-lsp.lsst.codes/chronograf/sources/1/dashboards/462?refresh=Paused&lower=now%28%29%20-%2015m>`_.
+
+.. _Vent-Gate-Extraction-Fan-Operation-CSC-Control:
+
+Set CSC Control
+---------------
+
+1.  Verify that ATBuilding CSC is ``ENABLED``. If not, enable it using either LOVE's 
+    `ASummaryState <https://summit-lsp.lsst.codes/love/uif/view?id=51>`_
+    or with the :file:`set_summary_state.py` script in 
+    `ATQueue <https://summit-lsp.lsst.codes/love/uif/view?id=41>`_.
+
+    .. code-block:: python
+        :caption: set_summary_state.py
+
+        data:
+            - [ATBuilding, ENABLED]
+
+2.  Change control of ATBuilding from *Manual* to *CSC* using the :file:`run_command.py` script
+    with the following configuration:
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanManualControlMode
+        parameters:
+           enableManualControlMode: False
+    
+    Check on Chronograph that the ``Extraction Fan Control Mode`` is now set to ``CSC``.
+
+.. _Vent-Gate-Extraction-Fan-Operation-Prepare-Venting:
+
+Prepare for Venting
+-------------------
+
+1.  Open vent gate #3, and confirm on Chronograf that the vent gate state
+    transitions from ``CLOSED`` to ``PARTIALLY_OPEN``.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: openVentGate
+        parameters:
+           gate: [2, -1, -1, -1]
+
+    .. note::
+
+        The array consists of four elements, corresponding to the four vent gates. 
+        To operate a specific gate, add its ID 
+        (gate IDs are numbered from 0-3, counter-clockwise from the front entrance door). 
+        If no gate operation is needed, use -1 as a placeholder.
+
+2.  Turn on the extraction fan at vent gate #3, and set the target frequency to 20Hz.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanDriveFreq
+        parameters:
+           targetFrequency: 20
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Stop-Venting:
+
+Stop Venting
+------------
+
+1.  Turn of the extraction fan at vent gate #3 by setting the target frequency to 0Hz.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanDriveFreq
+        parameters:
+           targetFrequency: 0
+
+2.  Close vent gate #3, and confirm on Chronograf that the vent gate state
+    transitions from ``PARTIALLY_OPEN`` to ``CLOSED``.
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: closeVentGate
+        parameters:
+           gate: [2, -1, -1, -1]
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Manual-Control:
+
+Set Manual Control
+------------------
+
+1.  Change control of ATBuilding from *CSC* to *Manual* using the :file:`run_command.py` script
+    with the following configuration:
+
+    .. code-block:: python
+        :caption: run_command.py
+
+        component: ATBuilding
+        cmd: setExtractionFanManualControlMode
+        parameters:
+           enableManualControlMode: False
+    
+    Check on Chronograph that the ``Extraction Fan Control Mode`` is now set to ``Manual``.
+
+2.  Set the ATBuilding CSC to ``STANDBY`` using either LOVE's 
+    `ASummaryState <https://summit-lsp.lsst.codes/love/uif/view?id=51>`_
+    or with the :file:`set_summary_state.py` script in 
+    `ATQueue <https://summit-lsp.lsst.codes/love/uif/view?id=41>`_ .
+
+    .. code-block:: python
+        :caption: set_summary_state.py
+
+        data:
+            - [ATBuilding, STANDBY]
+
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Troubleshooting:
+
+Troubleshooting
+===============
+
+     No troubleshooting information is applicable to this procedure.
+
+- This is an example bullet (If the following error is given during :ref:`Step 5 <Title-of-Procedure-Final-Step>`, resolve it using a specified action.)

--- a/AuxTel/Standard-Operations/Daytime-Operations/Vent-Gate-Extraction-Fan-Operation.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/Vent-Gate-Extraction-Fan-Operation.rst
@@ -199,6 +199,63 @@ Set Manual Control
 Troubleshooting
 ===============
 
-     No troubleshooting information is applicable to this procedure.
+.. _Vent-Gate-Extraction-Fan-Operation-Troubleshooting-Raspberry-Pi:
 
-- This is an example bullet (If the following error is given during :ref:`Step 5 <Title-of-Procedure-Final-Step>`, resolve it using a specified action.)
+Raspberry Pi Rebooting
+----------------------
+
+If any of the following issues occur:
+
+-  Inability to transition ATBuilding CSC to enable
+-  Commands are not producing the expected results
+-  Interruption in ATBuilding telemetry
+-  ATBuilding CSC enters FAULT mode
+
+Then the solution will be to restart the Raspberry Pi software on the AuxTel vent gate.
+
+1.  Using a command line, open a secure shell to the host :command:`auxtel-vent-gates01.cp.lsst.org` and
+    :command:`reboot` the Raspberry Pi.
+
+    .. code-block:: bash
+        
+        >> ssh auxtel-vent-gates01.cp.lsst.org
+        >> reboot
+
+2.  If the :command:`reboot` command does not work, restart the :command:`vent_controller` container.
+
+    .. code-block:: bash
+
+        >> ssh auxtel-vent-gates01.cp.lsst.org
+        >> docker run -d --restart unless-stopped --name vent_controller --device /dev/i2c-1 \
+              -p 0.0.0.0:17311:23 --user root \
+              lsstts/vents-controller-aarch64:k0003.001 --modbus-host auxtel-vent-fan01.cp.lsst.org
+
+3. If neither of the previous steps were successful, contact support on `#summit-auxtel <https://rubin-obs.slack.com/archives/C07Q45NUK4P>`_
+   for help on manually power cycling the Raspberry Pi.
+
+
+
+.. _Vent-Gate-Extraction-Fan-Operation-Troubleshooting-Manual-Operation:
+
+Vent Gate Manual Operation
+--------------------------
+
+In the case of an emergency, when remote connection of the vent gate is not possible, 
+observers may have to manually operate the vent gate and extraction fan to allow venting procedures to continue.
+
+1.  Verify and the vent gate controls are set to *Manual*. If not, follow instructions in the 
+    :ref:`Vent-Gate-Extraction-Fan-Operation-Manual-Control` section of this procedure.
+2.  Head to calibration hill, and locate vent gate #3 inside of the AuxTel dome. 
+    The vent gate is opposite of the main entrance on level 1.
+3.  Locate the vent gate control switch to the left of the vent gate (on the wall)
+    and the extraction fan controller to the right of the vent gate (see image below).
+
+    a.  If starting venting procedures, set the vent gate switch to ``OPEN``, and 
+        rotate the extraction dial clockwise until is reads **20Hz**.
+    b.  If stopping venting procedures, rotate the extraction dial counter-clockwise 
+        until is reads **0Hz**, and set the vent gate switch to ``CLOSED``.
+
+.. figure:: ./_static/PrepareforVent_AuxTel_VentGate3andFan.png
+      :name: Dome Vent Gate 3 and Extraction Fan 
+
+      AuxTel Dome Vent Gate #3 and Extraction Fan with Controller.

--- a/AuxTel/Standard-Operations/Daytime-Operations/Vent-Gate-Extraction-Fan-Operation.rst
+++ b/AuxTel/Standard-Operations/Daytime-Operations/Vent-Gate-Extraction-Fan-Operation.rst
@@ -73,6 +73,14 @@ Procedure Steps
     Monitor each step in the procedure using the 
     `ATBuilding Chronograf Dashboard <https://summit-lsp.lsst.codes/chronograf/sources/1/dashboards/462?refresh=Paused&lower=now%28%29%20-%2015m>`_.
 
+.. _Vent-Gate-Extraction-Fan-Operation-Activate:
+
+Activate Vent Gate and Extraction Fan
+*************************************
+
+This section outlines the steps required to open AuxTel's vent gate and power on the extraction fan.
+This procedure is for when AuxTel has begun its :ref:`venting procedures <AuxTel-Daytime-Operations-Prepare-for-vent>`.
+
 .. _Vent-Gate-Extraction-Fan-Operation-CSC-Control:
 
 Set CSC Control
@@ -135,6 +143,14 @@ Prepare for Venting
         parameters:
            targetFrequency: 20
 
+
+.. _Vent-Gate-Extraction-Fan-Operation-Deactivate:
+
+Deactivate Vent Gate and Extraction Fan
+***************************************
+
+This section outlines the steps required to close AuxTel's vent gate and power off the extraction fan.
+This procedure is for when AuxTel has begun its :ref:`on-sky procedures <AuxTel-Nighttime-Operations-Open-for-On-Sky-Operations>`.
 
 .. _Vent-Gate-Extraction-Fan-Operation-Stop-Venting:
 

--- a/AuxTel/Standard-Operations/Nighttime-Operations/Prepare-for-On-Sky-Operations.rst
+++ b/AuxTel/Standard-Operations/Nighttime-Operations/Prepare-for-On-Sky-Operations.rst
@@ -95,7 +95,8 @@ Procedure Steps
        * Activate AOS open loop corrections.
        * Enable dome following. 
 
-#. If the wind speed is below 8 m/s, open vent gate #3 and set the extractor fan to 20 Hz via :ref:`ATBuilding CSC <support-and-monitoring>`. If the wind speed is at or above 8 m/s, keep the vent gate closed and the extractor fan off.
+#. If the vent gate and extraction fan were used for venting, navigate to the :ref:`Vent-Gate-Extraction-Fan-Operation-Deactivate` procedure, and
+   follow the instructions to close vent gate #3 and power off the extraction fan.
 
 #. Visually confirm in `LOVE displays <http://love01.cp.lsst.org/uif/view?id=68>`__:
 

--- a/AuxTel/Standard-Operations/Nighttime-Operations/Prepare-for-On-Sky-Operations.rst
+++ b/AuxTel/Standard-Operations/Nighttime-Operations/Prepare-for-On-Sky-Operations.rst
@@ -8,7 +8,7 @@
 .. Include one Primary Author and list of Contributors (comma separated) between the asterisks (*):
 .. |author| replace:: *isotuela*
 .. If there are no contributors, write "none" between the asterisks. Do not remove the substitution.
-.. |contributors| replace:: *Gonzalo Aravena*
+.. |contributors| replace:: *Gonzalo Aravena, Erik Dennihy*
 
 .. This is the label that can be used as for cross referencing this procedure.
 .. Recommended format is "Directory Name"-"Title Name"  -- Spaces should be replaced by hyphens.
@@ -38,7 +38,7 @@ The Sun's coordinates at any given time, along with several other useful ephemer
 .. _Open-for-On-Sky-Operations-Precondition:
 
 Precondition
-=============
+============
 
 * Before deciding to open, review the weather conditions and :ref:`weather constraints <auxtel-weather-constraints-deciding-to-open>` page.
 
@@ -66,7 +66,8 @@ Procedure Steps
 ===============
 #. Review :ref:`preconditions <Open-for-On-Sky-Operations-Precondition>` and confirm they have been executed. 
 
-#. Announce in the #summit-announce and #summit-auxtel Slack channel that AuxTel is preparing to go on-sky. 
+#. Announce in the `#summit-announce <https://rubin-obs.slack.com/archives/C07QCJ7F962>`_ and `#summit-auxtel <https://rubin-obs.slack.com/archives/C07Q45NUK4P>`_ 
+   Slack channel that AuxTel is preparing to go on-sky. 
 
 #. Command the telescope and dome to prepare for on-sky observations. 
 
@@ -74,7 +75,7 @@ Procedure Steps
    The script will then be added to the script queue. 
    
    .. note::
-     If the ``auxtel/prepare_for/vent.py`` script is still running, the queue will run ``auxtel/prepare_for/onsky.py`` once venting is done, around 20 minutes before sunset.  
+     If the ``auxtel/prepare_for/vent.py`` script is still running, the queue will run ``auxtel/prepare_for/onsky.py`` once venting is done, which is right at sunset.  
 
    In the ``Configuring script:onsky`` screen that pops up, leave the ``CONFIG`` box empty. 
    Make sure there are no spaces in the ``CONFIG`` box, as this may prevent the script from configuring and loading correctly.
@@ -86,6 +87,8 @@ Procedure Steps
 
    The script includes the following steps:
 
+       * Take 3 bias exposures with LATISS to clear any residual accumulated charge.
+       * If the vent gates are open, it will close them and turn the extraction fan off. 
        * Slew telescope to az = 90 and el = 80, where it is least likely to be hit by the Sun. 
        * If primary mirror cover is open, the script will now close it. 
          This will protect the mirror and avoid particles and dust falling on it when the dome shutter opens.
@@ -95,7 +98,15 @@ Procedure Steps
        * Activate AOS open loop corrections.
        * Enable dome following. 
 
-#. If the wind speed is below 8 m/s, open vent gate #3 and set the extractor fan to 20 Hz via :ref:`ATBuilding CSC <support-and-monitoring>`. If the wind speed is at or above 8 m/s, keep the vent gate closed and the extractor fan off.
+#. Visually confirm Vent Gate 3 is closed and its extraction fault is off using the 
+   `ATBuilding Chronograf Dashboard <https://summit-lsp.lsst.codes/chronograf/sources/1/dashboards/462?refresh=Paused&lower=now%28%29%20-%2024h>`_.
+
+   .. note::
+
+    Should observers need to override the current state of Vent Gate 3 and its extraction fan, 
+    navigate to the :ref:`Vent-Gate-Extraction-Fan-Operation-Activate` procedure.
+    The page provides non-standard instructions to open/close Vent Gate 3 and power on/off the extraction fan.
+
 
 #. Visually confirm in `LOVE displays <http://love01.cp.lsst.org/uif/view?id=68>`__:
 


### PR DESCRIPTION
Hi @edennihy,

I finally got arround to updating the AuxTel venting procedures. I rearranged the procedures as follows:

1. Created a new standard procedure on operating the vent gate and extraction fan. Procedure steps are categorized into "Activate" (venting) and "Deactivate" (on-sky) subsections. Also added troubleshooting for restarting raspberry pi and manual operations.
2. Linked the new page to the venting and on-sky standard procedures. Removed any old references to manual operations of vent gate and extraction fan.

Please take a look and provide any comments. Thank you!