### PR TITLE
Include warning for controller reboot interlock issues

### DIFF
--- a/Simonyi/Non-Standard-Operations/MTCS/MTHexRot/MTRot-PXI-Controller-Reboot.rst
+++ b/Simonyi/Non-Standard-Operations/MTCS/MTHexRot/MTRot-PXI-Controller-Reboot.rst
@@ -56,6 +56,20 @@ one:
 - :ref:`Soft Reboot <MTRot-PXI-Controller-Reboot-Soft-Reboot>`
 - :ref:`Hard Reboot or Power off <MTRot-PXI-Controller-Reboot-Hard-Reboot>`
 
+.. warning::
+
+    	If the intention is to clear the interlock indicated in the EFD/EUI, rebooting the controller
+	may not resolve the issue, as the interlock signal is likely real rather than a result of a 
+	malfunctioning controller. It is most probable that the rotator locking pin is not properly positioned, 
+	especially after telescope tasks such as a Camera Filter Swap.
+
+	**Always check that the pin is securely in the unlocked position** 
+
+	Keep in mind that the hexapod and rotator controllers will automatically clear the cached interlock 
+	fault once the physical interlock signal is no longer present
+
+
+
 .. _MTRot-PXI-Controller-Reboot-Prerequisites:
 
 Prerequisites

--- a/Simonyi/Non-Standard-Operations/MTCS/MTHexRot/MTRot-PXI-Controller-Reboot.rst
+++ b/Simonyi/Non-Standard-Operations/MTCS/MTHexRot/MTRot-PXI-Controller-Reboot.rst
@@ -10,7 +10,7 @@
 .. Include one Primary Author and list of Contributors (comma separated) between the asterisks (*):
 .. |author| replace:: Ioana Sotuela, Te-Wei Tsai
 .. If there are no contributors, write "none" between the asterisks. Do not remove the substitution.
-.. |contributors| replace:: Kshitija Kelkar
+.. |contributors| replace:: Kshitija Kelkar, Paulina Venegas
 
 .. This is the label that can be used as for cross referencing this procedure.
 .. Recommended format is "Directory Name"-"Title Name"  -- Spaces should be replaced by hyphens.
@@ -63,11 +63,11 @@ one:
 	malfunctioning controller. It is most probable that the rotator locking pin is not properly positioned, 
 	especially after telescope tasks such as a Camera Filter Swap.
 
-	**Always check that the pin is securely in the unlocked position** 
+	**Always check that the pin is securely in the unlocked position.** 
 
-	Keep in mind that the hexapod and rotator controllers will automatically clear the cached interlock 
-	fault once the physical interlock signal is no longer present
+	The rotator (and the hexapod) controller will automatically clear the cached interlock fault once the physical interlock signal is no longer present.
 
+Link to the procedure for MTRotator to unlock the locking pin: https://rubinobs.atlassian.net/wiki/x/8KddAg
 
 
 .. _MTRot-PXI-Controller-Reboot-Prerequisites:
@@ -224,7 +224,7 @@ Hard Reboot
 
 .. warning::
 
-    **Only proceed with a hard reboot, if the EUI control connection remains unsucessful after 
+    **Only proceed with a hard reboot, if the EUI control connection remains unsuccessful after 
     a** :ref:`soft reboot <MTRot-PXI-Controller-Reboot-Soft-Reboot>`.
 
     This method involves cutting power to the PXI and drives and should only be used as a last resort 

--- a/Simonyi/Non-Standard-Operations/MTCS/MTHexRot/MTRot-PXI-Controller-Reboot.rst
+++ b/Simonyi/Non-Standard-Operations/MTCS/MTHexRot/MTRot-PXI-Controller-Reboot.rst
@@ -15,6 +15,7 @@
 .. This is the label that can be used as for cross referencing this procedure.
 .. Recommended format is "Directory Name"-"Title Name"  -- Spaces should be replaced by hyphens.
 .. _MTRot-PXI-Controller-Reboot:
+.. _MTRotator to unlock the locking pin: https://rubinobs.atlassian.net/wiki/x/8KddAg
 .. Each section should includes a label for cross referencing to a given area.
 .. Recommended format for all labels is "Title Name"-"Section Name" -- Spaces should be replaced by hyphens.
 .. To reference a label that isn't associated with an reST object such as a title or figure, you must include the link an explicit title using the syntax :ref:`link text <label-name>`.
@@ -67,7 +68,11 @@ one:
 
 	The rotator (and the hexapod) controller will automatically clear the cached interlock fault once the physical interlock signal is no longer present.
 
+<<<<<<< HEAD
 Link to the procedure for MTRotator to unlock the locking pin: https://rubinobs.atlassian.net/wiki/x/8KddAg
+=======
+    Link to the procedure for `MTRotator to unlock the locking pin`_
+>>>>>>> b53a88b (link added:MTRotator to unlock the locking pin)
 
 
 .. _MTRot-PXI-Controller-Reboot-Prerequisites:


### PR DESCRIPTION
Updated the documentation to clarify the interlock troubleshooting case. 
May the rotator locking pin not properly positioned