### PR TITLE
tickets/RSO-846

### DIFF
--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -1239,57 +1239,75 @@ MTCalSys
      - Command
      - SAL Script
      - Script Configuration
-   * - MTReflector
+   * - General
      - Open/close MTReflector
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
+     - To open MTReflector
+       
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTReflector
-          cmd: open
+        component: MTReflector
+        cmd: open
 
-       | (or ``cmd: close``)
+       To close the reflector, use ``cmd: close``.
 
    * -
-     - Park the calibration projector
+     - Park the Calibration Projector
      - :file:`maintel/park_calibration_projector.py`
      - No Configuration.
    * -
-     - Setup LEDProjector for White light flats
+     - Setup LEDProjector for White Light Flats
      - | :file:`maintel/setup_whitelight_flats.py`
        |
        | Default Configuration:
-       | ``sequence_name: "whitelight_u_source"``
-       | ``ignore: ['TunableLaser','LinearStage:104','FiberSpectrograph:101','FiberSpectrograph:102','CBP','Electrometer:102','Electrometer:101']``
-     - | .. code-block:: python
-          :caption: setup_whitelight_flats.py
+       
+       .. code-block:: python
+        
+        sequence_name: "whitelight_u_source"
+        ignore: ['TunableLaser','LinearStage:104',
+                 'CBP','Electrometer:101','Electrometer:102',
+                 'FiberSpectrograph:101', 'FiberSpectrograph:102']
 
-          sequence_name: 'laser_functional'
-          ignore: ['LinearStage:104','FiberSpectrograph:101','FiberSpectrograph:102','CBP','Electrometer:102','Electrometer:101']
+     - We can change the ``sequence_name`` and ``ignore`` unnecessary CSCs 
+       based on the provided test cases on Zephyr Scale.
+
+       .. code-block:: python
+        :caption: setup_whitelight_flats.py
+
+        sequence_name: 'laser_functional'
+        ignore: ['LinearStage:104', 'CBP',
+                 'Electrometer:102','Electrometer:101',
+                 'FiberSpectrograph:101','FiberSpectrograph:102']
 
    * -
-     - Take whitelight flats for a given setup
-     - | :file:`maintel/take_whitelight_flats_lsstcam.py`
-       | (`code <https://github.com/lsst-ts/ts_externalscripts/blob/develop/python/lsst/ts/externalscripts/maintel/take_whitelight_flats_lsstcam.py>`__)
+     - Take Specified Whitelight Flats
+     - | :file:`maintel/take_whitelight_flats_lsstcam.py` [`code <https://github.com/lsst-ts/ts_externalscripts/blob/develop/python/lsst/ts/externalscripts/maintel/take_whitelight_flats_lsstcam.py>`__]
        |
-       | Default will run for all installed filters:
-       | ``sequence_names: ["daily"]``
-       | Metadata: ``note``, ``reason``, ``program``
-     - | .. code-block:: python
-          :caption: take_whitelight_flats_lsstcam.py
+       | Default ``sequence_names: ["daily"]`` will run for all installed filters available (g, r, i, z, and u/y).
+       | Metadata parameters available: ``note``, ``reason``, and ``program``.
+     - The following is an example of a specific type Photon Transfer Curve (PTC) script used, 
+       where the data is collected for the test case **BLOCK-T572**:
 
-          sequence_names: ['low_level_ptc']
-          reason: "low_level_led_ptc"
-          program: "BLOCK-T572"
+       .. code-block:: python
+        :caption: take_whitelight_flats_lsstcam.py
+
+        sequence_names: ['low_level_ptc']
+        reason: "low_level_led_ptc"
+        program: "BLOCK-T572"
 
    * - CBP
-     - Move the CBP Az, El position
+     - Move the CBP to (Az, El) Position
      - | ``run_command.py``
        |
-       | ``azimuth`` and ``elevation`` are float in degrees.
+       | The ``azimuth`` and ``elevation`` parameters require floating point numbers measured in *degrees*.
+       |
+       | **Limits:**
        | Az: [-45.0 to 45.0 deg]
        | El: [-69.0 to 45.0 deg]
-     - | .. code-block:: python
+     - If we want to move the CBP to *Az = -0.05 deg* and *El = -46.5 deg*:
+
+       .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1299,11 +1317,24 @@ MTCalSys
             elevation: -46.5
 
    * -
-     - Change the CBP mask
-     - | ``run_command.py``
-       |
-       | There are 5 masks to characterize the beam projection.
-     - | .. code-block:: python
+     - Change the CBP Mask
+     - ``run_command.py``
+       
+       .. note::
+        There are 5 masks to characterize the beam projection. 
+        These are represented by strings of numbers: 
+        
+        * ``'1'``: LSSTCam 1 Pinhole per CCD Mask
+        * ``'2'``: 1mm Pinhole Mask
+        * ``'3'``: Empty Slot
+        * ``'4'``: ComCam 1 Pinhole per CCD Mask
+        * ``'5'``: 1 Pinhole per Amp Mask
+        
+        Selection of the mask type for a test case is determined typically by calibration team.
+
+     - If we want to change the current CBP mask to *mask position 1*:
+
+       .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1312,24 +1343,34 @@ MTCalSys
             mask: '1'
 
    * -
-     - Rotate the CBP mask
-     - | ``run_command.py``
-       |
-       | Rotation is between 1 and 360 deg.
-     - | .. code-block:: python
-          :caption: run_command.py
+     - Rotate the CBP Mask
+     - ``run_command.py``
 
-          component: CBP
-          cmd: changeMaskRotation
-          parameters:
-            mask_rotation: 96.5
+       .. note::
+        
+        Rotation is between 1 deg and 360 deg.
+
+     - If we want to rotate the CBP mask to 96.5 deg:
+
+       .. code-block:: python
+        :caption: run_command.py
+
+        component: CBP
+        cmd: changeMaskRotation
+        parameters:
+          mask_rotation: 96.5
 
    * -
-     - Set CBP focus
-     - | ``run_command.py``
-       |
-       | Focus in microns. Range is (0, 13000).
-     - | .. code-block:: python
+     - Set CBP Focus
+     - ``run_command.py``
+
+       .. note::
+
+        Focus is measured in microns, and its range is [0, 13000] microns.
+
+     - If we want to set the focus to *3800 microns*:
+
+       .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1338,18 +1379,32 @@ MTCalSys
             focus: 3800
 
    * -
-     - Park CBP (moves to elevation -70, locks the motors)
+     - Park CBP
      - ``run_command.py``
-     - | .. code-block:: python
+
+       .. note::
+
+        The CBP moves to elevation -70 deg, and it locks its motors when parking.
+
+     - 
+       .. code-block:: python
           :caption: run_command.py
 
           component: CBP
           cmd: park
 
    * - Tunable Laser
-     - Set tunable laser wavelength
+     - Set Tunable Laser Wavelength
      - ``run_command.py``
-     - | .. code-block:: python
+
+       .. note::
+
+        Laser wavelengths are measured in nanometers (nm), and the range is between 
+        350 - 1100nm during normal operations.
+
+     - To change the laser wavelength to *750nm*:
+
+       .. code-block:: python
           :caption: run_command.py
 
           component: TunableLaser
@@ -1358,11 +1413,16 @@ MTCalSys
             wavelength: 750
 
    * -
-     - Set laser output configuration
-     - | ``run_command.py``
-       |
-       | Configurations available: (see XML documentation)
-     - | .. code-block:: python
+     - Set Laser Output Configuration
+     - ``run_command.py``
+       
+       .. note::
+        
+        Available optical configurations are located in the `XML documentation <https://ts-xml.lsst.io/sal_interfaces/TunableLaser.html#enumerations>`__.
+
+     - To set the configuration to *F2 SCU*:
+
+       .. code-block:: python
           :caption: run_command.py
 
           cmd: setOpticalConfiguration
@@ -1370,39 +1430,39 @@ MTCalSys
             configuration: F2 SCU
 
    * -
-     - Change tunable laser mode
-     - | ``run_command.py``
-       |
-       | Available modes: ``setBurstMode`` and ``setContinuousMode``.
-     - | .. code-block:: python
+     - Change Tunable Laser Mode
+     - ``run_command.py``
+
+       .. note::
+
+        There are two available laser modes: *Burst Mode* (``setBurstMode``) 
+        and *Continuous Mode* (``setContinuousMode``).
+
+     - To set the tunable laser to *burst mode*:
+
+       .. code-block:: python
           :caption: run_command.py
 
           component: TunableLaser
           cmd: setBurstMode
 
    * -
-     - Start/stop tunable laser propagation
-     - | ``run_command.py``
-       |
-       | Start cmd: ``startPropagateLaser``
-       | Stop cmd: ``stopPropagateLaser``
-       |
-       | Note: requires setting the mode first.
-     - | .. code-block:: python
-          :caption: run_command.py
-
-          component: TunableLaser
-          cmd: startPropagateLaser
-
-   * -
-     - Set laser output to F2 SCU
+     - Start/Stop Tunable Laser Propagation
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
 
-          cmd: setOpticalConfiguration
-          parameters:
-            configuration: F2 SCU
+       .. note::
+        It is required to set the laser mode (burst/continous) *first* before 
+        activating the laser propagation.
+
+     - To start propagation:
+
+       .. code-block:: python
+        :caption: run_command.py
+
+        component: TunableLaser
+        cmd: startPropagateLaser
+
+       To stop propagation, set ``cmd: stopPropagateLaser``.
 
 
 .. _Simonyi-SAL-Scripts-Scheduler:

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -63,7 +63,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Check M1M3 Hardpoint Breakaway
      - | :file:`/check_hardpoint.py`
        |
-       | Default config:
+       | Default Configuration:
        
        .. code-block:: python
         
@@ -79,7 +79,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - M1M3 Bump Test Any/All Actuators
      - | :file:`/check_actuators.py`
        |
-       | Default config:
+       | Default Configuration:
 
        .. code-block:: python
         
@@ -140,7 +140,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - M2 Bump Test Any/All Actuators
      - | :file:`/check_actuators.py`
        |
-       | Default config:
+       | Default Configuration:
        
        .. code-block:: python
         
@@ -183,7 +183,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
      - | :file:`enable_hexapod_compensation_mode.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_hexapod_compensation_mode.py>`__]
        | :file:`disable_hexapod_compensation_mode.py`
        |
-       | Default config applies to both hexapods:
+       | Default Configuration applies to both hexapods:
 
        .. code-block:: python
         
@@ -342,7 +342,7 @@ MTMount
    * - Move TMA Point-to-Point
      - | :file:`{p1}/move_p2p.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/move_p2p.py>`__]
        |
-       | Default config:
+       | Default Configuration:
 
        .. code-block:: python
         
@@ -383,7 +383,7 @@ MTMount
    * - Point (Az, El)
      - | :file:`{p1}/point_azel.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_point_azel.py>`__]
        |
-       | Default Config:
+       | Default Configuration:
 
        .. code-block:: python
         
@@ -405,12 +405,12 @@ MTMount
        * `rot_type Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L230>`__
        * `az_wrap_strategy Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L270>`__
 
-       | Default Config:
+       | Default Configuration:
        
        .. code-block:: python
         
-        offset: {x: 0, y: 0}``
-        differential_tracking: {dra: 0.0, ddec: 0.0}``
+        offset: {x: 0, y: 0}
+        differential_tracking: {dra: 0.0, ddec: 0.0}
         rot_type: "SkyAuto"
         rot_value: 0
         track_for: 0
@@ -525,54 +525,67 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Command
      - SAL Script
      - Script Configuration
-   * - Issue correction
+   * - Issue MTAOS Correction
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTAOS
-          cmd: issueCorrection
+        component: MTAOS
+        cmd: issueCorrection
 
-   * - Reset correction
+   * - Reset MTAOS Correction
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTAOS
-          cmd: resetCorrection
+        component: MTAOS
+        cmd: resetCorrection
 
-   * - Reset Offset DOF
+   * - Reset Applied Offsets to Degrees of Freedom (DOF)
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTAOS
-          cmd: resetOffsetDOF
+        component: MTAOS
+        cmd: resetOffsetDOF
 
    * - Enable/Disable AOS closed-loop
-     - | :file:`enable_aos_closed_loop.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_aos_closed_loop.py>`__)
-       | :file:`disable_aos_closed_loop.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/disable_aos_closed_loop.py>`__)
-     - | .. code-block:: python
-          :caption: enable_aos_closed_loop.py
+     - | :file:`enable_aos_closed_loop.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_aos_closed_loop.py>`__]
+       | :file:`disable_aos_closed_loop.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/disable_aos_closed_loop.py>`__]
+     - Default Configuration:
+       
+       .. code-block:: python
+        :caption: enable_aos_closed_loop.py
+        
+        truncation_index: 12
+        used_dofs: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,30,31,32,33,34]
+       
+       Higher selectivity of DOFs, truncation, zernikes, etc. 
+       can be done, with the approval of the AOS team:
+       
+       .. code-block:: python
 
-          used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-          truncation_index: [2]
-          zn_selected: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22, 27, 28]
+        used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        truncation_index: [2]
+        zn_selected: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22, 27, 28]
 
-   * - Set the absolute state of the telescope DOFs
+   * - Set Telescope DOFs
      - | :file:`set_dof.py`
        |
-       | No default configuration.
-       | To ignore a component:
-       |
-       | ``ignore:``
-       | ``- mtmount``
-       | ``- mthexapod_1``
-       | ``- mthexapod_2``
-       | ``- mtrotator``
-     - | Uses a **previous image**:
+       | To ignore specific components:
+
+       .. code-block:: python
+        
+        ignore:
+          - mtmount
+          - mthexapod_1
+          - mthexapod_2
+          - mtrotator
+
+     - Select DOFs from a **previous image**:
 
        .. code-block:: python
           :caption: set_dof.py
@@ -580,7 +593,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
           day: 20250630
           seq: 457
 
-       | Apply **individual dofs** (microns or arcsec):
+       Apply **individual DOFs** (microns or arcsec):
 
        .. code-block:: python
 
@@ -590,44 +603,47 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
           # Example: M2 hexapod offset in x
           M2_dx: 5
 
-       | Apply **multiple dofs** (50-dimensional vector):
-       | [0-4]: M2 Rigid Body Motions
-       | [5-9]: Camera Rigid Body Motions
-       | [10-29]: M1M3 Bending Modes
-       | [30-49]: M2 Bending Modes
+       Apply **multiple DOFs** (50-dimensional vector):
+       
+       * [0-4]: M2 Rigid Body Motions
+       * [5-9]: Camera Rigid Body Motions
+       * [10-29]: M1M3 Bending Modes
+       * [30-49]: M2 Bending Modes
 
        .. code-block:: python
 
           dofs: [0.0, 1.0, 2.0, 3.0, 4.0,
-          5.0, 6.0, 7.0, 8.0, 9.0,
-          10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0,
-          20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
-          30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0,
-          40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0]
+                 5.0, 6.0, 7.0, 8.0, 9.0,
+                 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0,
+                 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
+                 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0,
+                 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0]
 
-   * - Apply a DOF to the main telescope (bending mode or hexapod offset)
+   * - Apply DOFs to Telescope
      - :file:`apply_dof.py`
      - Same configurations as ``set_dof.py``.
-   * - Enable and run closed-loop system on the AOS for LSSTCam
+   * - Run Closed-Loop System on AOS
      - :file:`close_loop_lsstcam.py`
-     - | .. code-block:: python
-          :caption: close_loop_lsstcam.py
+     - Higher selectivity of script parameters can be done, with the approval of the AOS team.
 
-          exposure_time: 15
-          max_iter: 5
-          mode: "FAM"
-          program: "BLOCK-T249"
-          note: "initial_focus_dzs_tilts_bending_modes"
-          used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, 28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 45, 46]
-          apply_corrections: true
-          use_ocps: true
-          filter: "r_03"
+       .. code-block:: python
+        :caption: close_loop_lsstcam.py
 
-   * - Adjust M2/Camera Hexapods to focus PSFs manually
+        exposure_time: 15
+        max_iter: 5
+        mode: "FAM"
+        program: "BLOCK-T249"
+        note: "initial_focus_dzs_tilts_bending_modes"
+        used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, 28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 45, 46]
+        apply_corrections: true
+        use_ocps: true
+        filter: "r_03"
+
+   * - Offset M2/Camera Hexapods (PSF Focus)
      - | :file:`offset_m2_hexapod.py`
        | :file:`offset_camera_hexapod.py`
      - | If the first image shows a donut rather than a PSF, adjust by hand.
-       | Change the camera hexapod z by Dz = [(donut diameter in pixels) * 12] microns.
+       | Change the camera hexapod z by **Dz = [(donut diameter in pixels) * 12]** microns.
 
        .. code-block:: python
           :caption: offset_camera_hexapod.py
@@ -643,22 +659,27 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Take Triplet Sequence with LSSTCam
      - | :file:`take_aos_sequence_lsstcam.py`
        |
-       | Defaults:
-       | ``filter:``
-       | ``exposure_time: 30``
-       | ``dz: 1500``
-       | ``n_sequences: 1``
-       | ``mode: TRIPLET``
-       | ``program: AOSSEQUENCE``
-     - | .. code-block:: python
-          :caption: take_aos_sequence_lsstcam.py
+       | Default Configurations:
 
-          filter: z_03
-          exposure_time: 10
-          dz: 800
-          mode: TRIPLET
-          program: AOSSEQUENCE
-          reason: "test"
+       .. code-block:: python
+        
+        filter: current_filter
+        exposure_time: 30
+        dz: 1500
+        n_sequences: 1
+        mode: TRIPLET
+        program: AOSSEQUENCE
+
+     - 
+       .. code-block:: python
+        :caption: take_aos_sequence_lsstcam.py
+
+        filter: z_20
+        exposure_time: 10
+        dz: 800
+        mode: TRIPLET
+        program: AOSSEQUENCE
+        reason: "test"
 
 
 .. _Simonyi-SAL-Scripts-MTDome:
@@ -681,58 +702,61 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Command
      - SAL Script
      - Script Configuration
-   * - Enable/Disable dome following mode
-     - | :file:`/enable_dome_following.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/enable_dome_following.py>`__)
+   * - Enable/Disable Dome Following Mode
+     - | :file:`/enable_dome_following.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/enable_dome_following.py>`__]
        | :file:`/disable_dome_following.py`
      - No Configuration.
-   * - Offset MTDome in Az
-     - | :file:`/offset_dome.py`
-       |
-       | Units of ``az`` in degrees.
-     - | .. code-block:: python
-          :caption: offset_dome.py
+   * - Offset Dome Azimuth
+     - :file:`/offset_dome.py`
+     - Units of ``az`` in degrees.
 
-          offset: 10
+       .. code-block:: python
+        :caption: offset_dome.py
 
-   * - Slew MTDome in Az
-     - | :file:`/slew_dome.py`
-       |
-       | Units of ``az`` in degrees.
-     - | .. code-block:: python
-          :caption: slew_dome.py
+        offset: 10
 
-          az: 70
-          ignore:
-            - mtmount
-            - mthexapod_1
-            - mthexapod_2
+   * - Slew Dome in Azimuth
+     - :file:`/slew_dome.py`
+     - | Units of ``az`` in degrees. 
+       | If needed, CSC components can be ignored with the ``ignore`` parameter.
 
-   * - Park / Unpark MTDome
-     - | :file:`/park_dome.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/park_dome.py>`__)
-       | :file:`/unpark_dome.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/unpark_dome.py>`__)
-     - | .. code-block:: python
-          :caption: park_dome.py
+       .. code-block:: python
+        :caption: slew_dome.py
 
-          ignore:
-            - mtm1m3
-            - mtm2
-            - mtaos
-            - mtdometrajectory
-            - mthexapod_1
-            - mthexapod_2
+        az: 70
+        ignore:
+          - mtmount
+          - mthexapod_1
+          - mthexapod_2
+
+   * - Park/Unpark Dome
+     - | :file:`/park_dome.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/park_dome.py>`__]
+       | :file:`/unpark_dome.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/unpark_dome.py>`__]
+     - If needed, CSC components can be ignored with the ``ignore`` parameter. 
+     
+       .. code-block:: python
+        :caption: park_dome.py
+
+        ignore:
+          - mtm1m3
+          - mtm2
+          - mtaos
+          - mtdometrajectory
+          - mthexapod_1
+          - mthexapod_2
 
    * - Open/Close MTDome
-     - | :file:`/open_dome.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/open_dome.py>`__)
+     - | :file:`/open_dome.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/open_dome.py>`__]
        | :file:`/close_dome.py`
        |
        | Both scripts have the ``force`` property, useful to bypass errors
-       | or conditions (e.g., dome telemetry reports shutters in wrong state,
-       | mirror covers lost instead of closed).
-     - | No Configuration., but you can ignore certain CSCs:
+         or conditions (e.g., dome telemetry reports shutters in wrong state,
+         mirror covers lost instead of closed).
+       |
+       | The dome can also open/close via a direct override using a ``run_command.py`` script,
+         if the normal SAL Script fails to execute properly.
+
+     - No Configuration., but you can ignore CSCs with the ``ignore`` parameter:
 
        .. code-block:: python
           :caption: open_dome.py
@@ -748,10 +772,8 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
             - mtmount
             - mtptg
             - mtrotator
-
-   * - Open/Close MTDome (via run_command)
-     - ``run_command.py``
-     - | To open:
+      
+       To open the dome with a ``run_command.py``:
 
        .. code-block:: python
           :caption: run_command.py
@@ -759,121 +781,131 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           component: MTDome
           cmd: openShutter
 
-       | To close:
+       To close the dome with a ``run_command.py``:
 
        .. code-block:: python
 
           component: MTDome
           cmd: closeShutter
 
-   * - Open Dome Louvers
+   * - Open/Close Dome Louvers
      - | ``run_command.py``
        |
        | The array values are between 0.0 (**closed**) and 100.0 (fully **open**).
        |
-       | Louver index (0-based):
+       | Louver Index (0-based):
        | [A1, A2, **B1**, B2, B3, C1, C2, C3, D1, D2, D3, **E1**, **E2**, E3,
-       | F1, F2, F3, G1, G2, G3, **H1**, **H2**, H3, I1, I2, I3, L1, L2, L3,
-       | **M1**, M2, M3, N1, N2]
-       |
-       | Bold = louvers available as of 2026-2-14.
-     - | .. code-block:: python
+         F1, F2, F3, G1, G2, G3, **H1**, **H2**, H3, I1, I2, I3, L1, L2, L3,
+         **M1**, M2, M3, N1, N2]
+
+     - If one wants to open the mechanical louvers **highlighted in bold** in the *Louver Index*:
+
+       .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
           cmd: setLouvers
           parameters:
             position: [0.0, 0.0, 100.0, 0.0, 0.0,
-          0.0, 0.0, 0.0, 0.0, 0.0,
-          0.0, 100.0, 100.0, 0.0, 0.0,
-          0.0, 0.0, 0.0, 0.0, 0.0,
-          100.0, 100.0, 0.0, 0.0, 0.0,
-          0.0, 0.0, 0.0, 0.0, 100.0,
-          0.0, 0.0, 0.0, 0.0]
+                       0.0, 0.0, 0.0, 0.0, 0.0,
+                       0.0, 100.0, 100.0, 0.0, 0.0,
+                       0.0, 0.0, 0.0, 0.0, 0.0,
+                       100.0, 100.0, 0.0, 0.0, 0.0,
+                       0.0, 0.0, 0.0, 0.0, 100.0,
+                       0.0, 0.0, 0.0, 0.0]
+    
+       To close all louvers:
 
-   * - Close Dome Louvers
-     - | ``run_command.py``
-       |
-       | Alternatively use the ``setLouvers`` command with value 0 in the
-       | louver index you want to close.
-     - | .. code-block:: python
+       .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
           cmd: closeLouvers
 
-   * - Stop dome and engage brakes
+       Alternatively, one can use the ``setLouvers`` command with value 0 in the
+       louver indices to close specific louvers and leave others open.
+
+   * - Stop Dome and Engage Brakes
      - | ``run_command.py``
        |
-       | ``stop`` `command <https://ts-xml.lsst.io/sal_interfaces/MTDome.html#stop>`__
-       | DomeAz: ``subSystemIds: 0x1``
-       | Dome shutter: ``subSystemIds: 0x4``
-       | Louvers: ``subSystemIds: 0x8``
-     - | .. code-block:: python
-          :caption: run_command.py
+       | Dome ``subSystemIds``:
+       * Dome Azimuth: ``0x1``
+       * Dome Shutter: ``0x4``
+       * Louvers: ``0x8``
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTDome
-          cmd: stop
-          parameters:
-            engageBrakes: true
-            subSystemIds: 0x?
+        component: MTDome
+        cmd: stop
+        parameters:
+          engageBrakes: true
+          subSystemIds: 0x1
 
-   * - Recover from Dome Az FAULT
-     - | :file:`/recover_from_controller_fault.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/recover_from_controller_fault.py>`__)
-       |
-       | ``delta_move: 3.0``
-       |
-       | Clears a dome controller fault, moves the dome slightly to confirm
-       | it works again, and re-enables dome following if successful.
-     - No Configuration. required
-   * - Exit Fault/Clear fault in subsystem
+   * - Recover from Dome Azimuth Fault
+     - :file:`/recover_from_controller_fault.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/recover_from_controller_fault.py>`__]
+       
+       #. Clears the current dome controller fault.
+       #. Turns on drives and moves the dome slightly to confirm fault is cleared.
+       #. Re-enables dome following if able to move again.
+     - No Configuration.
+   * - Clear Dome Subsystem Fault
      - | ``run_command.py``
        |
-       | DomeAz: ``subSystemIds: 0x1``
-       | Dome shutter: ``subSystemIds: 0x4``
-       | Louvers: ``subSystemIds: 0x8``
-     - | .. code-block:: python
-          :caption: run_command.py
-
-          component: MTDome
-          cmd: exitFault
-          parameters:
-            subSystemIds: 0x?
-
-   * - Reset dome drives
-     - | ``run_command.py``
+       | Command will also reset dome/shutter drives (see below)
+         internally when attempting to clear faults on those subsystems.
        |
-       | (``exitFault`` will issue a ``resetDrivesAz`` internally; probably not needed)
-     - | .. code-block:: python
-          :caption: run_command.py
+       | Dome ``subSystemIds``:
+       * Dome Azimuth: ``0x1``
+       * Dome Shutter: ``0x4``
+       * Louvers: ``0x8``
+     - Most common subsystem fault is the Dome Azimuth Drives:
 
-          component: MTDome
-          cmd: resetDrivesAz
-          parameters:
-            reset: [1,1,1,1,1]
+       .. code-block:: python
+        :caption: run_command.py
 
-   * - Reset Dome shutter drives
+        component: MTDome
+        cmd: exitFault
+        parameters:
+          subSystemIds: 0x1
+
+   * - Reset Dome Azimuth Drives
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
+     - To reset all dome azimuth drives:
 
-          component: MTDome
-          cmd: resetDrivesShutter
-          parameters:
-            reset: [1,1,1,1]
+       .. code-block:: python
+        :caption: run_command.py
 
-   * - Home Dome Az
+        component: MTDome
+        cmd: resetDrivesAz
+        parameters:
+          reset: [1,1,1,1,1]
+
+   * - Reset Dome Shutter Drives
+     - ``run_command.py``
+     - To reset all dome shutter drives:
+     
+       .. code-block:: python
+        :caption: run_command.py
+
+        component: MTDome
+        cmd: resetDrivesShutter
+        parameters:
+          reset: [1,1,1,1]
+
+   * - Home Dome Azimuth
      - | :file:`/home_dome.py`
        |
-       | Required: ``physical_az`` (azimuth position as read by markings).
+       | Required: ``physical_az`` (azimuth position as read by markings inside the dome).
        |
-       | See `Homing MTDome procedure <https://rubinobs.atlassian.net/wiki/spaces/OOD/pages/705003522>`__.
-     - | .. code-block:: python
-          :caption: home_dome.py
+       | See `Homing MTDome Procedure <https://rubinobs.atlassian.net/wiki/spaces/OOD/pages/705003522>`__.
+     - If the dome is parked, and its physical azimuth reads **310 deg**, instead of its true home position (328 deg):
 
-          physical_az: <physical position as read by markings>
-          ignore:
+       .. code-block:: python
+        :caption: home_dome.py
+
+        physical_az: 310
+        ignore:
             - mtm1m3
             - mtm2
             - mtaos
@@ -884,45 +916,56 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
             - mtptg
             - mtrotator
 
-   * - Home Dome shutter
+   * - Home Dome Shutter
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
+     - Remember to include the ``subSystemIds`` parameter:
 
-          component: MTDome
-          cmd: home
-          parameters:
-            subSystemIds: 0x4
+       .. code-block:: python
+        :caption: run_command.py
 
-   * - Set dome shutter to degraded mode
-     - | ``run_command.py``
-       |
-       | Dome operational modes:
-       | **1:** Normal mode
-       | **2:** Degraded mode
-     - | .. code-block:: python
-          :caption: run_command.py
+        component: MTDome
+        cmd: home
+        parameters:
+          subSystemIds: 0x4
 
-          component: MTDome
-          cmd: setOperationalMode
-          parameters:
-            operationalMode: 2
-            subSystemIds: 0x4
+   * - Set Dome Shutter to Degraded Mode
+     - ``run_command.py``
+       
+       Dome operational modes:
 
-   * - Crawl - Move the azimuth axis at constant velocity
-     - | :file:`/crawl_az.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/crawl_az.py>`__)
+       * ``1``: Normal Mode
+       * ``2``: Degraded Mode (10% Performance)
+
+     - Remember to include the ``subSystemIds`` parameter:
+
+       .. code-block:: python
+        :caption: run_command.py
+
+        component: MTDome
+        cmd: setOperationalMode
+        parameters:
+          operationalMode: 2
+          subSystemIds: 0x4
+
+   * - Rotate Dome at Constant Velocity
+     - | :file:`/crawl_az.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/crawl_az.py>`__]
        |
        | Includes ``position`` and ``velocity`` properties.
-       | Speed in deg/second.
+         Velocity is measured in deg/second.
        |
-       | Default config:
-       | ``direction: ClockWise``
-     - | .. code-block:: python
-          :caption: crawl_az.py
+       | Default Configuration:
 
-          direction: CounterClockWise
-          velocity: 0.5
+       .. code-block:: python
+        
+        direction: ClockWise
+
+     - If we want to move the dome counter-clockwise at a rate of 0.5 deg/second:
+
+       .. code-block:: python
+        :caption: crawl_az.py
+
+        direction: CounterClockWise
+        velocity: 0.5
 
 
 .. _Simonyi-SAL-Scripts-LSSTCam:
@@ -949,7 +992,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Focus Sweep
      - | :file:`focus_sweep_lsstcam.py`
        |
-       | Properties with default config:
+       | Properties with Default Configuration:
        | ``sim: false``
        | ``hexapod: Camera``
        | ``filter: null``
@@ -1086,7 +1129,7 @@ LaserTracker
      - | :file:`laser_tracker/align.py`
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/laser_tracker/align.py>`__)
        |
-       | Default config:
+       | Default Configuration:
        | ``max_iter: 10``
        | ``tolerance_linear: 0.0001`` (meters)
        | ``tolerance_angular: 0.00138`` (deg, ~5 arcsec)
@@ -1151,7 +1194,7 @@ MTCalSys
      - Setup LEDProjector for White light flats
      - | :file:`maintel/setup_whitelight_flats.py`
        |
-       | Default config:
+       | Default Configuration:
        | ``sequence_name: "whitelight_u_source"``
        | ``ignore: ['TunableLaser','LinearStage:104','FiberSpectrograph:101','FiberSpectrograph:102','CBP','Electrometer:102','Electrometer:101']``
      - | .. code-block:: python
@@ -1397,7 +1440,7 @@ General Scripts
    * - Checks and prepares key telescope systems
      - | :file:`ensure_on_sky_readiness.py`
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/ensure_onsky_readiness.py>`__)
-     - | Default config:
+     - | Default Configuration:
 
        .. code-block:: python
           :caption: ensure_on_sky_readiness.py

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -179,15 +179,17 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Command
      - SAL Script
      - Script Configuration
-   * - Turning on compensation mode
-     - | :file:`enable_hexapod_compensation_mode.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_hexapod_compensation_mode.py>`__)
+   * - Enable/Disable Compensation Mode
+     - | :file:`enable_hexapod_compensation_mode.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_hexapod_compensation_mode.py>`__]
        | :file:`disable_hexapod_compensation_mode.py`
        |
        | Default config applies to both hexapods:
-       |
-       | ``components: ["M2Hexapod", "CameraHexapod"]``
-     - | For M2 Hexapod only:
+
+       .. code-block:: python
+        
+        components: ["M2Hexapod", "CameraHexapod"]
+
+     - For M2 Hexapod only:
 
        .. code-block:: python
           :caption: enable_hexapod_compensation_mode.py
@@ -195,24 +197,25 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
           components:
             - M2Hexapod
 
-       | For Camera Hexapod only:
+       For Camera Hexapod only:
 
        .. code-block:: python
 
           components:
             - CameraHexapod
 
-   * - Resetting M2 Hexapod (MTHexapod:2) or Camera Hexapod (MTHexapod:1) to a zero position
+   * - Reset M2/Camera Hexapod Positions
      - | ``run_command.py``
        |
        | For Camera Hexapod use ``component: MTHexapod:1``
        | For M2 Hexapod use ``component: MTHexapod:2``
-     - | .. code-block:: python
-          :caption: run_command.py
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTHexapod:2
-          cmd: move
-          parameters:
+        component: MTHexapod:2
+        cmd: move
+        parameters:
             x: 0
             y: 0
             z: 0
@@ -222,20 +225,11 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
        | **x, y, z** position in **microns** and **u, v, w** rotation in **degrees**.
 
-   * - Offset Camera Hexapod / Offset M2 Hexapod
+   * - Offset M2/Camera Hexapods
      - | :file:`offset_camera_hexapod.py`
        | :file:`offset_m2_hexapod.py`
        |
-       | Same schema for both SAL scripts.
-       | Properties:
-       |
-       | ``x:``
-       | ``y:``
-       | ``z:``
-       | ``u:``
-       | ``v:``
-       | ``reset_axes: false``
-       |
+       | **Properties:** ``x``, ``y``, ``z``, ``u``, ``v``, and ``reset_axes``.
        | **x, y, z** position in **microns** and **u, v** rotation in **degrees**.
      - | Reset the positions before applying offsets in x, z and u axes:
 
@@ -259,26 +253,27 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
           reset_axes: ["x", "z", "u"]
 
-   * - Enable Hexapods with new Configuration
+   * - Change Hexapod YAML Configuration
      - ``set_summary_state.py``
-     - | .. code-block:: python
-          :caption: set_summary_state.py
+     - 
+       .. code-block:: python
+        :caption: set_summary_state.py
 
-          data:
-            -
-              - MTHexapod:1
-              - Standby
-            -
-              - MTHexapod:1
-              - Enabled
-              - laser_rotation_elevation_v18.yaml
-            -
-              - MTHexapod:2
-              - Standby
-            -
-              - MTHexapod:2
-              - Enabled
-              - laser_rotation_elevation_v18.yaml
+        data:
+          -
+            - MTHexapod:1
+            - Standby
+          -
+            - MTHexapod:1
+            - Enabled
+            - laser_rotation_elevation_v18.yaml
+          -
+            - MTHexapod:2
+            - Standby
+          -
+            - MTHexapod:2
+            - Enabled
+            - laser_rotation_elevation_v18.yaml
 
 
 .. _Simonyi-SAL-Scripts-MTRotator:

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -127,26 +127,29 @@ MTM2
 Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m2`
 
 .. list-table::
-   :widths: 20 40 40
+   :widths: 40 30 30
    :header-rows: 1
 
    * - Command
      - SAL Script
      - Script Configuration
-   * - Enable/disable M2 closed-loop
+   * - Enable/Disable M2 Closed-Loop
      - | :file:`/enable_m2_closed_loop.py`
-       | :file:`/m2/disable_m2_closed_loop.py`
+       | :file:`/disable_m2_closed_loop.py`
      - No configuration
-   * - Perform a M2 bump test on either a selection of individual actuators or on all axial actuators
+   * - M2 Bump Test Any/All Actuators
      - | :file:`/check_actuators.py`
        |
        | Default config:
-       |
-       | ``actuators: all``
-       | ``ignore_actuators: []``
-       | ``period: 60``
-       | ``force: 10``
-     - | Write specific actuators in an array to bump test only those:
+       
+       .. code-block:: python
+        
+        actuators: all
+        ignore_actuators: []
+        period: 60
+        force: 10
+
+     - Write specific actuators in an array to bump test only those:
 
        .. code-block:: python
           :caption: check_actuators.py
@@ -155,7 +158,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           period: 5
           force: 10
 
-       | Or ignore certain actuators:
+       Or ignore certain actuators:
 
        .. code-block:: python
 

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -46,7 +46,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - No Configuration.
    * - Slew Flags
      - :file:`/enable_m1m3_slew_controller_flags.py`
-     - Default Configuration:
+     - Configuration for normal operations:
 
        .. code-block:: python
         :caption: enable_m1m3_slew_controller_flags.py
@@ -61,13 +61,15 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | :file:`/disable_m1m3_balance_system.py`
      - No Configuration.
    * - Check M1M3 Hardpoint Breakaway
-     - | :file:`/check_hardpoint.py`
-       |
-       | Default Configuration:
+     - :file:`/check_hardpoint.py`
        
-       .. code-block:: python
+       .. note::
         
-        hardpoints: all
+        Default Configuration:
+        
+        .. code-block:: python
+          
+          hardpoints: all
 
      - To check specific hardpoints:
 
@@ -77,14 +79,16 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           hardpoints: [1, 2, 4]
 
    * - M1M3 Bump Test Any/All Actuators
-     - | :file:`/check_actuators.py`
-       |
-       | Default Configuration:
+     - :file:`/check_actuators.py`
 
-       .. code-block:: python
+       .. note::
         
-        actuators: all
-        ignore_actuators: []
+        Default Configuration:
+        
+        .. code-block:: python
+          
+          actuators: all
+          ignore_actuators: []
 
      - Provide a list of the ``actuators`` to test:
 
@@ -138,16 +142,18 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | :file:`/disable_m2_closed_loop.py`
      - No Configuration.
    * - M2 Bump Test Any/All Actuators
-     - | :file:`/check_actuators.py`
-       |
-       | Default Configuration:
-       
-       .. code-block:: python
+     - :file:`/check_actuators.py`
+
+       .. note::
         
-        actuators: all
-        ignore_actuators: []
-        period: 60
-        force: 10
+        Default Configuration:
+        
+        .. code-block:: python
+          
+          actuators: all
+          ignore_actuators: []
+          period: 60
+          force: 10
 
      - Write specific actuators in an array to bump test only those:
 
@@ -182,12 +188,14 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Enable/Disable Compensation Mode
      - | :file:`enable_hexapod_compensation_mode.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_hexapod_compensation_mode.py>`__]
        | :file:`disable_hexapod_compensation_mode.py`
-       |
-       | Default Configuration applies to both hexapods:
-
-       .. code-block:: python
+       
+       .. note::
         
-        components: ["M2Hexapod", "CameraHexapod"]
+        Default Configuration applies to both hexapods:
+        
+        .. code-block:: python
+        
+          components: ["M2Hexapod", "CameraHexapod"]
 
      - For M2 Hexapod only:
 
@@ -205,10 +213,13 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
             - CameraHexapod
 
    * - Reset M2/Camera Hexapod Positions
-     - | ``run_command.py``
-       |
-       | For Camera Hexapod use ``component: MTHexapod:1``
-       | For M2 Hexapod use ``component: MTHexapod:2``
+     - ``run_command.py``
+       
+       .. note::
+        
+        For Camera Hexapod use ``component: MTHexapod:1``
+        For M2 Hexapod use ``component: MTHexapod:2``
+
      - 
        .. code-block:: python
         :caption: run_command.py
@@ -228,9 +239,12 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Offset M2/Camera Hexapods
      - | :file:`offset_camera_hexapod.py`
        | :file:`offset_m2_hexapod.py`
-       |
-       | **Properties:** ``x``, ``y``, ``z``, ``u``, ``v``, and ``reset_axes``.
-       | **x, y, z** position in **microns** and **u, v** rotation in **degrees**.
+      
+       .. note::
+        
+        | **Properties:** ``x``, ``y``, ``z``, ``u``, ``v``, and ``reset_axes``.
+        | **x, y, z** position in **microns** and **u, v** rotation in **degrees**.
+
      - | Reset the positions before applying offsets in x, z and u axes:
 
        .. code-block:: python
@@ -291,10 +305,13 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - SAL Script
      - Script Configuration
    * - Move Rotator Angle
-     - | :file:`/move_rotator.py` (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtrotator/move_rotator.py>`__)
-       |
-       | ``angle`` range: [-89, +89] degrees.
-     - 
+     - :file:`/move_rotator.py` (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtrotator/move_rotator.py>`__)
+       
+       .. note::
+
+        ``angle`` range: [-89, +89] degrees.
+     - To move the rotator to -45 deg:
+  
        .. code-block:: python
         :caption: move_rotator.py
 
@@ -323,12 +340,15 @@ MTMount
    * - Home TMA Axes
      - :file:`{p1}/home_both_axes.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/home_both_axes.py>`__]
        
-       | Requires MTDome CSC in ``ENABLED`` or ``DISABLED``.
-       |
-       | Enables **M1M3 force balance system** and M2Hex and Cam Hex **compensation mode**.
-       |
-       | Offers the option to move to another position and home again.
-     - 
+       .. note::
+
+        | Requires MTDome CSC in ``ENABLED`` or ``DISABLED``.
+        |
+        | Script enables **M1M3 force balance system** and M2Hex and Cam Hex **compensation mode**.
+        | It also offers the option to move to another position and home again.
+
+     - To home both axes at the position *Az = 1 deg* and *El = 46 deg*:
+
        .. code-block:: python
         :caption: home_both_axes.py
 
@@ -341,13 +361,15 @@ MTMount
 
    * - Move TMA Point-to-Point
      - | :file:`{p1}/move_p2p.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/move_p2p.py>`__]
-       |
-       | Default Configuration:
-
-       .. code-block:: python
+       
+       .. note::
         
-        pause_for: 0
-        move_timeout: 120.0
+        Default Configuration:
+
+        .. code-block:: python
+        
+          pause_for: 0
+          move_timeout: 120.0
        
      - Select a single point in Az (deg), El (deg) or in RA (hrs), Dec (deg):
 
@@ -381,18 +403,21 @@ MTMount
         For (RA, Dec) arrays, sexagesimals may be added as strings.
 
    * - Point (Az, El)
-     - | :file:`{p1}/point_azel.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_point_azel.py>`__]
-       |
-       | Default Configuration:
-
-       .. code-block:: python
+     - :file:`{p1}/point_azel.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_point_azel.py>`__]
+       
+       .. note::
         
-        rot_tel: 0.0
-        target_name: "AzEl"
-        wait_dome: false
-        slew_timeout: 240.0
+        Default Configuration:
 
-     - 
+        .. code-block:: python
+        
+          rot_tel: 0.0
+          target_name: "AzEl"
+          wait_dome: false
+          slew_timeout: 240.0
+
+     - To point the telescope at *Az = 80 deg* and *El = 80 deg*:
+
        .. code-block:: python
         :caption: point_azel.py
 
@@ -402,21 +427,24 @@ MTMount
    * - Track Target
      - :file:`{p1}/track_target.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_track_target.py>`__]
        
-       * `rot_type Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L230>`__
-       * `az_wrap_strategy Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L270>`__
-
-       | Default Configuration:
-       
-       .. code-block:: python
+       .. note::
         
-        offset: {x: 0, y: 0}
-        differential_tracking: {dra: 0.0, ddec: 0.0}
-        rot_type: "SkyAuto"
-        rot_value: 0
-        track_for: 0
-        stop_when_done: false
-        az_wrap_strategy: "OPTIMIZE"
-        slew_timeout: 240
+        Default Configuration:
+       
+        .. code-block:: python
+        
+          offset: {x: 0, y: 0}
+          differential_tracking: {dra: 0.0, ddec: 0.0}
+          rot_type: "SkyAuto"
+          rot_value: 0
+          track_for: 0
+          stop_when_done: false
+          az_wrap_strategy: "OPTIMIZE"
+          slew_timeout: 240
+
+        * `rot_type Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L230>`__
+        * `az_wrap_strategy Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L270>`__
+
        
        
      - | Slew and track ICRS RA, Dec coordinates.
@@ -467,9 +495,12 @@ MTMount
      - | :file:`{p1}/open_mirror_covers.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/open_mirror_covers.py>`__]
        | :file:`{p1}/close_mirror_covers.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/close_mirror_covers.py>`__]
 
-       * If El < 20°, script moves TMA to El 20°.
-       * Closes (deploys) OR opens (retracts) the mirror covers.
-       * Lock M1M3 mirror covers.
+       .. note::
+        
+        * If El < 20°, script moves TMA to El 20°.
+        * Closes (deploys) OR opens (retracts) the mirror covers.
+        * Lock M1M3 mirror covers.
+  
      - No Configuration.
    * - Change TMA Performance Settings
      - ``run_command.py``
@@ -478,7 +509,8 @@ MTMount
         
         Remember to restore to default, as the settings are cumulative.
 
-     - 
+     - To set MTMount to 10% performance settings:
+
        .. code-block:: python
         :caption: run_command.py
 
@@ -573,17 +605,19 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
         zn_selected: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22, 27, 28]
 
    * - Set Telescope DOFs
-     - | :file:`set_dof.py`
-       |
-       | To ignore specific components:
-
-       .. code-block:: python
+     - :file:`set_dof.py`
+       
+       .. note::
         
-        ignore:
-          - mtmount
-          - mthexapod_1
-          - mthexapod_2
-          - mtrotator
+        To ignore specific components:
+
+        .. code-block:: python
+        
+          ignore:
+            - mtmount
+            - mthexapod_1
+            - mthexapod_2
+            - mtrotator
 
      - Select DOFs from a **previous image**:
 
@@ -657,20 +691,23 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
           z: +2 x Dz
 
    * - Take Triplet Sequence with LSSTCam
-     - | :file:`take_aos_sequence_lsstcam.py`
-       |
-       | Default Configurations:
-
-       .. code-block:: python
+     - :file:`take_aos_sequence_lsstcam.py`
+       
+       .. note::
         
-        filter: current_filter
-        exposure_time: 30
-        dz: 1500
-        n_sequences: 1
-        mode: TRIPLET
-        program: AOSSEQUENCE
+        Default Configurations:
 
-     - 
+        .. code-block:: python
+        
+          filter: current_filter
+          exposure_time: 30
+          dz: 1500
+          n_sequences: 1
+          mode: TRIPLET
+          program: AOSSEQUENCE
+
+     - The following is an example AOS sequence used in testing:
+       
        .. code-block:: python
         :caption: take_aos_sequence_lsstcam.py
 
@@ -748,13 +785,15 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Open/Close MTDome
      - | :file:`/open_dome.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/open_dome.py>`__]
        | :file:`/close_dome.py`
-       |
-       | Both scripts have the ``force`` property, useful to bypass errors
-         or conditions (e.g., dome telemetry reports shutters in wrong state,
-         mirror covers lost instead of closed).
-       |
-       | The dome can also open/close via a direct override using a ``run_command.py`` script,
-         if the normal SAL Script fails to execute properly.
+       
+       .. note::
+        
+        Both scripts have the ``force`` property, useful to bypass errors
+        or conditions (e.g., dome telemetry reports shutters in wrong state,
+        mirror covers lost instead of closed).
+       
+        The dome can also open/close via a direct override using a ``run_command.py`` script,
+        if the normal SAL Script fails to execute properly.
 
      - No Configuration., but you can ignore CSCs with the ``ignore`` parameter:
 
@@ -789,14 +828,16 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           cmd: closeShutter
 
    * - Open/Close Dome Louvers
-     - | ``run_command.py``
-       |
-       | The array values are between 0.0 (**closed**) and 100.0 (fully **open**).
-       |
-       | Louver Index (0-based):
-       | [A1, A2, **B1**, B2, B3, C1, C2, C3, D1, D2, D3, **E1**, **E2**, E3,
-         F1, F2, F3, G1, G2, G3, **H1**, **H2**, H3, I1, I2, I3, L1, L2, L3,
-         **M1**, M2, M3, N1, N2]
+     - ``run_command.py``
+       
+       .. note::
+        
+        | The array values are between 0.0 (**closed**) and 100.0 (fully **open**).
+       
+        | Louver Index (0-based):
+        | [A1, A2, **B1**, B2, B3, C1, C2, C3, D1, D2, D3, 
+         **E1**, **E2**, E3, F1, F2, F3, G1, G2, G3, **H1**, **H2**, 
+         H3, I1, I2, I3, L1, L2, L3, **M1**, M2, M3, N1, N2]
 
      - If one wants to open the mechanical louvers **highlighted in bold** in the *Louver Index*:
 
@@ -826,12 +867,16 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        louver indices to close specific louvers and leave others open.
 
    * - Stop Dome and Engage Brakes
-     - | ``run_command.py``
-       |
-       | Dome ``subSystemIds``:
-       * Dome Azimuth: ``0x1``
-       * Dome Shutter: ``0x4``
-       * Louvers: ``0x8``
+     - ``run_command.py``
+      
+       .. note:: 
+        
+        Dome ``subSystemIds``:
+
+        * Dome Azimuth: ``0x1``
+        * Dome Shutter: ``0x4``
+        * Louvers: ``0x8``
+  
      - 
        .. code-block:: python
         :caption: run_command.py
@@ -845,20 +890,29 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Recover from Dome Azimuth Fault
      - :file:`/recover_from_controller_fault.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/recover_from_controller_fault.py>`__]
        
-       #. Clears the current dome controller fault.
-       #. Turns on drives and moves the dome slightly to confirm fault is cleared.
-       #. Re-enables dome following if able to move again.
+       .. note::
+
+        The script does the following:
+
+        #. Clears the current dome controller fault.
+        #. Turns on drives and moves the dome slightly to confirm fault is cleared.
+        #. Re-enables dome following if able to move again.
+
      - No Configuration.
    * - Clear Dome Subsystem Fault
      - | ``run_command.py``
-       |
-       | Command will also reset dome/shutter drives (see below)
-         internally when attempting to clear faults on those subsystems.
-       |
-       | Dome ``subSystemIds``:
-       * Dome Azimuth: ``0x1``
-       * Dome Shutter: ``0x4``
-       * Louvers: ``0x8``
+       
+       .. note:: 
+        
+        Command will also reset dome/shutter drives (see below)
+        internally when attempting to clear faults on those subsystems.
+       
+        Dome ``subSystemIds``:
+
+        * Dome Azimuth: ``0x1``
+        * Dome Shutter: ``0x4``
+        * Louvers: ``0x8``
+
      - Most common subsystem fault is the Dome Azimuth Drives:
 
        .. code-block:: python
@@ -894,11 +948,13 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           reset: [1,1,1,1]
 
    * - Home Dome Azimuth
-     - | :file:`/home_dome.py`
-       |
-       | Required: ``physical_az`` (azimuth position as read by markings inside the dome).
-       |
-       | See `Homing MTDome Procedure <https://rubinobs.atlassian.net/wiki/spaces/OOD/pages/705003522>`__.
+     - :file:`/home_dome.py`
+       
+       .. note::
+        
+        | Required: ``physical_az`` (azimuth position as read by markings inside the dome).
+        | See `Homing MTDome Procedure <https://rubinobs.atlassian.net/wiki/spaces/OOD/pages/705003522>`__.
+
      - If the dome is parked, and its physical azimuth reads **310 deg**, instead of its true home position (328 deg):
 
        .. code-block:: python
@@ -931,10 +987,12 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Set Dome Shutter to Degraded Mode
      - ``run_command.py``
        
-       Dome operational modes:
+       .. note::
+        
+        Dome operational modes:
 
-       * ``1``: Normal Mode
-       * ``2``: Degraded Mode (10% Performance)
+        * ``1``: Normal Mode
+        * ``2``: Degraded Mode (10% Performance)
 
      - Remember to include the ``subSystemIds`` parameter:
 
@@ -948,16 +1006,20 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           subSystemIds: 0x4
 
    * - Rotate Dome at Constant Velocity
-     - | :file:`/crawl_az.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/crawl_az.py>`__]
-       |
-       | Includes ``position`` and ``velocity`` properties.
-         Velocity is measured in deg/second.
-       |
-       | Default Configuration:
-
-       .. code-block:: python
+     - :file:`/crawl_az.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/crawl_az.py>`__]
+       
+       .. note::
         
-        direction: ClockWise
+        Includes ``position`` and ``velocity`` properties.
+        
+        * ``position`` is measures in **deg**.
+        * ``velocity`` is measured in **deg/second**.
+       
+        Default Configuration:
+
+        .. code-block:: python
+        
+          direction: ClockWise
 
      - If we want to move the dome counter-clockwise at a rate of 0.5 deg/second:
 
@@ -1001,26 +1063,28 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
      - No Configuration.
    * - Execute Focus Sweep
-     - | :file:`focus_sweep_lsstcam.py`
-       | 
-       | Properties with Default Configurations:
+     - :file:`focus_sweep_lsstcam.py`
 
-       .. code-block:: python
-
-        sim: false
-        hexapod: Camera
-        filter: null
-        exp_time: 10
-        axis: ["x", "y", "z", "u", "v"]
-        focus_window:
-        n_steps:
-        focus_step_sequence:
-        n_images_per_step: 1
-        program: FOCUS_SWEEP
-        reason: null
-        ignore:
+       .. note:: 
         
-       | Units for ``focus_window`` and ``focus_step_sequence`` are in *microns*.
+        Properties with Default Configurations:
+
+        .. code-block:: python
+
+          sim: false
+          hexapod: Camera
+          filter: null
+          exp_time: 10
+          axis: ["x", "y", "z", "u", "v"]
+          focus_window:
+          n_steps:
+          focus_step_sequence:
+          n_images_per_step: 1
+          program: FOCUS_SWEEP
+          reason: null
+          ignore:
+        
+        Units for ``focus_window`` and ``focus_step_sequence`` are in **microns**.
 
      - | Required for defined focus window — use ``axis``, ``focus_window`` and ``n_steps``:
 
@@ -1061,23 +1125,23 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Take Image
      - :file:`take_image_lsstcam.py`
        
-       Typical Configurations Include:
+       .. note::
 
-       .. code-block:: python
+        Typical Configurations Include:
 
-        filter: # Current Filter.
-        nimages: # (Optional) Number of images.
-        exp_times: # Number of seconds (scalar or array).
-        image_type: # One of ["BIAS", "DARK", "FLAT", 
+        .. code-block:: python
+
+          filter: # Current Filter.
+          nimages: # (Optional) Number of images.
+          exp_times: # Number of seconds (scalar or array).
+          image_type: # One of ["BIAS", "DARK", "FLAT", 
                     #         "OBJECT", "ENGTEST", "ACQ", 
                     #         "SPOT", "CWFS", "FOCUS"].
-        reason: # (Optional) Short reason for image(s).
-        program: # (Optional) Test case used for the images.
-        note: # (Optional) Additional notes to add.
-       
-       .. note::
+          reason: # (Optional) Short reason for image(s).
+          program: # (Optional) Test case used for the images.
+          note: # (Optional) Additional notes to add.
         
-        Required Parameters: ``exp_times`` and ``image_type``.
+        *Required Parameters:* ``exp_times`` and ``image_type``.
 
      - Take a single five-second bias image:
 
@@ -1135,18 +1199,20 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Take AOS Triplet Sequence
      - :file:`maintel/take_aos_sequence_lsstcam.py`
        
-       Default Configurations:
-
-       .. code-block:: python
+       .. note::
         
-        filter: # Current filter.
-        exposure_time: 30
-        dz: 1500
-        n_sequences: 1
-        mode: TRIPLET
-        program: AOSSEQUENCE
+        Default Configurations:
 
-       | Units for ``dz`` are in *microns*.
+        .. code-block:: python
+        
+          filter: # Current filter.
+          exposure_time: 30
+          dz: 1500
+          n_sequences: 1
+          mode: TRIPLET
+          program: AOSSEQUENCE
+
+        Units for ``dz`` are in **microns**.
 
      - One can always add a ``reason`` to the triplet sequence.
      
@@ -1174,24 +1240,23 @@ LaserTracker
      - SAL Script
      - Script Configuration
    * - Align the TMA to the Calibration Screen
-     - | :file:`laser_tracker/align.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/laser_tracker/align.py>`__]
-       |
-       | Default Configuration:
-
-       .. code-block:: python
-        
-        max_iter: 10
-        tolerance_linear: 0.0001 # in meters
-        tolerance_angular: 0.00138 # in deg (~5 arcsec)
-        target: "M2" 
-        # Target Options (REQUIRED): 
-        # "M2", "Camera", or "CALIBRATION_SCREEN"
-
+     - :file:`laser_tracker/align.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/laser_tracker/align.py>`__]
+       
        .. note::
         
         The LaserTracker alignment of the Calibration Screen is now done by
         using ``id: BLOCK-T495`` in the :ref:`scheduler/add_block.py <Simonyi-SAL-Scripts-Scheduler>` script.
 
+        Default Configuration:
+
+        .. code-block:: python
+        
+          max_iter: 10
+          tolerance_linear: 0.0001 # in meters
+          tolerance_angular: 0.00138 # in deg (~5 arcsec)
+          target: "M2" 
+          # Target Options (REQUIRED): 
+          # "M2", "Camera", or "CALIBRATION_SCREEN"
         
      - To align to the calibration screen with a 0.01 deg angular tolerance:
        
@@ -1258,16 +1323,18 @@ MTCalSys
      - No Configuration.
    * -
      - Setup LEDProjector for White Light Flats
-     - | :file:`maintel/setup_whitelight_flats.py`
-       |
-       | Default Configuration:
+     - :file:`maintel/setup_whitelight_flats.py`
        
-       .. code-block:: python
+       .. note::
         
-        sequence_name: "whitelight_u_source"
-        ignore: ['TunableLaser','LinearStage:104',
-                 'CBP','Electrometer:101','Electrometer:102',
-                 'FiberSpectrograph:101', 'FiberSpectrograph:102']
+        Default Configuration:
+       
+        .. code-block:: python
+        
+          sequence_name: "whitelight_u_source"
+          ignore: ['TunableLaser','LinearStage:104',
+                   'CBP','Electrometer:101','Electrometer:102',
+                   'FiberSpectrograph:101', 'FiberSpectrograph:102']
 
      - We can change the ``sequence_name`` and ``ignore`` unnecessary CSCs 
        based on the provided test cases on Zephyr Scale.
@@ -1282,10 +1349,13 @@ MTCalSys
 
    * -
      - Take Specified Whitelight Flats
-     - | :file:`maintel/take_whitelight_flats_lsstcam.py` [`code <https://github.com/lsst-ts/ts_externalscripts/blob/develop/python/lsst/ts/externalscripts/maintel/take_whitelight_flats_lsstcam.py>`__]
-       |
-       | Default ``sequence_names: ["daily"]`` will run for all installed filters available (g, r, i, z, and u/y).
-       | Metadata parameters available: ``note``, ``reason``, and ``program``.
+     - :file:`maintel/take_whitelight_flats_lsstcam.py` [`code <https://github.com/lsst-ts/ts_externalscripts/blob/develop/python/lsst/ts/externalscripts/maintel/take_whitelight_flats_lsstcam.py>`__]
+       
+       .. note::
+        
+        | Default ``sequence_names: ["daily"]`` will run for all installed filters available (g, r, i, z, and u/y).
+        | Metadata parameters available: ``note``, ``reason``, and ``program``.
+
      - The following is an example of a specific type Photon Transfer Curve (PTC) script used, 
        where the data is collected for the test case **BLOCK-T572**:
 
@@ -1298,13 +1368,16 @@ MTCalSys
 
    * - CBP
      - Move the CBP to (Az, El) Position
-     - | ``run_command.py``
-       |
-       | The ``azimuth`` and ``elevation`` parameters require floating point numbers measured in *degrees*.
-       |
-       | **Limits:**
-       | Az: [-45.0 to 45.0 deg]
-       | El: [-69.0 to 45.0 deg]
+     - ``run_command.py``
+       
+       .. note::
+
+        | The ``azimuth`` and ``elevation`` parameters require floating point numbers measured in *degrees*.
+        |
+        | **Limits:**
+        | Az: [-45.0 to 45.0 deg]
+        | El: [-69.0 to 45.0 deg]
+        
      - If we want to move the CBP to *Az = -0.05 deg* and *El = -46.5 deg*:
 
        .. code-block:: python
@@ -1471,44 +1544,53 @@ Scheduler
 =========
 
 .. list-table::
-   :widths: 20 40 40
+   :widths: 20 50 30
    :header-rows: 1
 
    * - Command
      - SAL Script
      - Script Configuration
-   * - Enable Scheduler:1
-     - | :file:`maintel/scheduler/enable.py`
-       |
-       | Properties: ``config`` (string): Name of the configuration .yaml file.
-       | This loads the .yaml configuration file and can also be used to
-       | state-cycle the scheduler.
-     - | .. code-block:: python
-          :caption: maintel/scheduler/enable.py
+   * - Enable Simonyi Scheduler
+     - :file:`maintel/scheduler/enable.py`
+       
+       .. note::
+        
+        Properties: ``config`` (string): Name of the configuration .yaml file.
+        
+        This loads the .yaml configuration file and can also be used to state-cycle the scheduler.
 
-          config: <config_file_name>.yaml
+     - If we want to enable the standard configuration for the LSST survey:
+     
+       .. code-block:: python
+        :caption: maintel/scheduler/enable.py
 
-   * - Start scheduler-driven observations
+        config: fbs_config_lsst_survey.yaml
+
+   * - Start Scheduler-Driven Observations
      - :file:`maintel/scheduler/resume.py`
      - No Configuration.
-   * - Stop scheduler-driven observations
+   * - Stop Scheduler-Driven Observations
      - :file:`maintel/scheduler/stop.py`
      - No Configuration.
-   * - Start a testing BLOCK
-     - | :file:`maintel/scheduler/add_block.py`
-       |
-       | Properties:
-       | ``id`` (string): Name of the BLOCK to be run.
-       | ``override``: List of parameters to be changed/updated in the BLOCK.
-       |
-       | Current available BLOCKs listed
-       | `here <https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=10064>`__.
-     - | e.g. Measurement of Laser Tracker targets:
+   * - Start a Testing BLOCK
+     - :file:`maintel/scheduler/add_block.py`
+       
+       .. note::
+        
+        Properties:
+        
+        * ``id`` (string): Name of the BLOCK to be run.
+        * ``override``: List of parameters to be changed/updated in the BLOCK.
+       
+        Current available BLOCKs listed
+        `here <https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=10064>`__.
+
+     - If we wanted to run the initial alignment for Simonyi (BLOCK-T539):
 
        .. code-block:: python
           :caption: maintel/scheduler/add_block.py
 
-          id: BLOCK-T89
+          id: BLOCK-T539
 
 
 .. _Simonyi-SAL-Scripts-General:

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -506,7 +506,7 @@ MTMount
        .. admonition:: DO NOT USE!
         :class: warning
 
-        Currently in testing (2026-6-16).
+        Currently in testing as of |today|.
 
      - No Configuration.
 
@@ -884,7 +884,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Reset Dome Shutter Drives
      - ``run_command.py``
      - To reset all dome shutter drives:
-     
+
        .. code-block:: python
         :caption: run_command.py
 
@@ -983,30 +983,45 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
      - SAL Script
      - Script Configuration
    * - Enable LSSTCam
-     - | :file:`enable_lsstcam.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_lsstcam.py>`__)
-     - Not available
-   * - Put LSSTCam in STANDBY
-     -
-     - Not available
-   * - Focus Sweep
+     - :file:`enable_lsstcam.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_lsstcam.py>`__]
+
+       .. admonition:: DO NOT USE!
+        :class: warning
+
+        Not available as of |today|.
+
+     - No Configuration.
+   * - Standby LSSTCam
+     - :file:`standby_lsstcam.py`
+       
+       .. admonition:: DO NOT USE!
+        :class: warning
+
+        Not available as of |today|.
+
+     - No Configuration.
+   * - Execute Focus Sweep
      - | :file:`focus_sweep_lsstcam.py`
-       |
-       | Properties with Default Configuration:
-       | ``sim: false``
-       | ``hexapod: Camera``
-       | ``filter: null``
-       | ``exp_time: 10``
-       | ``axis: ["x", "y", "z", "u", "v"]``
-       | ``focus_window:``
-       | ``n_steps:``
-       | ``focus_step_sequence:``
-       | ``n_images_per_step: 1``
-       | ``program: FOCUS_SWEEP``
-       | ``reason: null``
-       | ``ignore:``
-       |
-       | Units are microns.
+       | 
+       | Properties with Default Configurations:
+
+       .. code-block:: python
+
+        sim: false
+        hexapod: Camera
+        filter: null
+        exp_time: 10
+        axis: ["x", "y", "z", "u", "v"]
+        focus_window:
+        n_steps:
+        focus_step_sequence:
+        n_images_per_step: 1
+        program: FOCUS_SWEEP
+        reason: null
+        ignore:
+        
+       | Units for ``focus_window`` and ``focus_step_sequence`` are in *microns*.
+
      - | Required for defined focus window — use ``axis``, ``focus_window`` and ``n_steps``:
 
        .. code-block:: python
@@ -1029,88 +1044,121 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
           reason: "Sweep in y"
 
    * - Change Filter
-     - | :file:`change_filter_lsstcam.py`
-       |
-       | Required: ``filter``
-     - | .. code-block:: python
+     - :file:`change_filter_lsstcam.py`
+
+       .. warning::
+
+        MTMount and MTRotator CSCs must be ``ENABLED`` for the script to run.
+       
+     - The ``filter`` parameter is required for this script. 
+       To change to the ``z_20`` filter:
+
+       .. code-block:: python
           :caption: change_filter_lsstcam.py
 
-          filter: <filter_name>
+          filter: z_20
 
    * - Take Image
-     - | :file:`take_image_lsstcam.py`
-       |
-       | ``filter:``
-       | ``nimages: null``
-       | ``exp_times: 0``
-       | ``image_type: ["BIAS", "DARK", "FLAT", "OBJECT", "ENGTEST", "ACQ", "SPOT", "CWFS", "FOCUS"]``
-       | ``reason:``
-       | ``program:``
-       | ``note:``
-       |
-       | Required: ``image_type``
-     - | .. code-block:: python
-          :caption: take_image_lsstcam.py
-
-          image_type: BIAS
+     - :file:`take_image_lsstcam.py`
+       
+       Typical Configurations Include:
 
        .. code-block:: python
 
-          image_type: FLAT
-          exp_times: 5
-          nimages: 2
-          reason: "flat_test"
+        filter: # Current Filter.
+        nimages: # (Optional) Number of images.
+        exp_times: # Number of seconds (scalar or array).
+        image_type: # One of ["BIAS", "DARK", "FLAT", 
+                    #         "OBJECT", "ENGTEST", "ACQ", 
+                    #         "SPOT", "CWFS", "FOCUS"].
+        reason: # (Optional) Short reason for image(s).
+        program: # (Optional) Test case used for the images.
+        note: # (Optional) Additional notes to add.
+       
+       .. note::
+        
+        Required Parameters: ``exp_times`` and ``image_type``.
+
+     - Take a single five-second bias image:
+
+       .. code-block:: python
+        
+        :caption: take_image_lsstcam.py
+
+        image_type: BIAS
+        exp_times: 5
+
+       Take two five-second flat images (with a reason):
 
        .. code-block:: python
 
-          image_type: ACQ
-          exp_times: 1
-          program: "BLOCK-TXXXX"
+        image_type: FLAT
+        exp_times: 5
+        nimages: 2
+        reason: "flat_test"
+
+       Take a single one-second acquisition image for a test case:
 
        .. code-block:: python
 
-          image_type: ENGTEST
-          exp_times: 30
-          nimages: 1
+        image_type: ACQ
+        exp_times: 1
+        program: "BLOCK-TXXXX"
 
-   * - Track target and take image
+       Take a single 30-second engineering test image:
+
+       .. code-block:: python
+
+        image_type: ENGTEST
+        exp_times: 30
+        nimages: 1
+
+   * - Track Target and Take Image
      - :file:`track_target_and_take_image_lsstcam.py`
-     - | All these are required:
+     - | All of the following parameters are required:
 
        .. code-block:: python
           :caption: track_target_and_take_image_lsstcam.py
 
-          ra:
-          dec:
-          rot_sky:
-          name:
-          obs_time:
-          num_exp:
-          exp_times:
-          band_filter:
+          ra: # ICRS right ascension (hour) in decimal hours or sexagesimal strings.
+          dec: # ICRS declination (deg) in decimal hours or sexagesimal strings.
+          rot_sky: # The position angle (deg) in the sky.
+          name: # Target name.
+          obs_time: # Time given for starting the slew
+          num_exp: # Number of exposures.
+          exp_times: # Array of exposure times in seconds.
+          band_filter: # Filter used for observation.
 
-   * - Take Stuttered
+   * - Take Stuttered Sequence
      - :file:`take_stuttered_lsstcam.py`
-     - | Configuration in
-       | `take_stuttered_lsstcam.py source <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/take_stuttered_lsstcam.py>`__
-   * - Take Triplets
-     - | :file:`maintel/take_aos_sequence_lsstcam.py`
-       |
-       | ``filter:``
-       | ``exposure_time: 30``
-       | ``dz: 1500``
-       | ``n_sequences: 1``
-       | ``mode: TRIPLET``
-       | ``program: AOSSEQUENCE``
-     - | .. code-block:: python
-          :caption: take_aos_sequence_lsstcam.py
+     - Configuration can be found in `take_stuttered_lsstcam.py source <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/take_stuttered_lsstcam.py>`__.
+   * - Take AOS Triplet Sequence
+     - :file:`maintel/take_aos_sequence_lsstcam.py`
+       
+       Default Configurations:
 
-          filter: z_03
-          exposure_time: 10
-          dz: 800
-          mode: TRIPLET
-          program: AOSSEQUENCE
-          reason: "test"
+       .. code-block:: python
+        
+        filter: # Current filter.
+        exposure_time: 30
+        dz: 1500
+        n_sequences: 1
+        mode: TRIPLET
+        program: AOSSEQUENCE
+
+       | Units for ``dz`` are in *microns*.
+
+     - One can always add a ``reason`` to the triplet sequence.
+     
+       .. code-block:: python
+        :caption: take_aos_sequence_lsstcam.py
+
+        filter: z_20
+        exposure_time: 10
+        dz: 800
+        mode: TRIPLET
+        program: AOSSEQUENCE
+        reason: "test"
 
 
 .. _Simonyi-SAL-Scripts-LaserTracker:

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -34,86 +34,89 @@ MTM1M3
 Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m1m3`
 
 .. list-table::
-   :widths: 20 40 40
+   :widths: 40 30 30
    :header-rows: 1
 
    * - Command
      - SAL Script
      - Script Configuration
-   * - Raise M1M3 / Lower M1M3
-     - | :file:`/raise_m1m3.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/m1m3/raise_m1m3.py>`__)
+   * - Raise/Lower M1M3
+     - | :file:`/raise_m1m3.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/m1m3/raise_m1m3.py>`__]
        | :file:`/lower_m1m3.py`
      - No configuration
    * - Slew Flags
-     - | :file:`/enable_m1m3_slew_controller_flags.py`
-       |
-       | Default config:
-       |
-       | ``slew_flags: [ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES, BOOSTERVALVES]``
-       | ``enable: [True, True, True, False]``
-     - | .. code-block:: text
-          :caption: enable_m1m3_slew_controller_flags.py
+     - :file:`/enable_m1m3_slew_controller_flags.py`
+     - Default Configuration:
 
-          slew_flags: [ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES, BOOSTERVALVES]
-          enable: [True, True, True, False]
+       .. code-block:: python
+        :caption: enable_m1m3_slew_controller_flags.py
 
-       | Defaults as of May 2025:
-       | ``ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES: True``
-       | ``BOOSTERVALVES: False``
-   * - Enable Force Balance System / Disable Force Balance System
+        slew_flags: [ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES, BOOSTERVALVES]
+        enable: [True, True, True, True]
+
+       To disable a specific slew flag, change the appropriate boolean to ``False``.
+
+   * - Enable/Disable Force Balance System
      - | :file:`/enable_m1m3_balance_system.py`
        | :file:`/disable_m1m3_balance_system.py`
      - No configuration
-   * - Check M1M3 Individual hardpoint breakaway
+   * - Check M1M3 Hardpoint Breakaway
      - | :file:`/check_hardpoint.py`
        |
        | Default config:
-       |
-       | ``hardpoints: all``
-     - | To check specific hardpoints:
+       
+       .. code-block:: python
+        
+        hardpoints: all
 
-       .. code-block:: text
+     - To check specific hardpoints:
+
+       .. code-block:: python
           :caption: check_hardpoint.py
 
           hardpoints: [1, 2, 4]
 
-   * - Bump test on either a selection of individual actuators or on all actuators
+   * - M1M3 Bump Test Any/All Actuators
      - | :file:`/check_actuators.py`
        |
        | Default config:
-       |
-       | ``actuators: all``
-       | ``ignore_actuators: []``
-     - | Provide a list of the ``actuators`` to test:
 
-       .. code-block:: text
+       .. code-block:: python
+        
+        actuators: all
+        ignore_actuators: []
+
+     - Provide a list of the ``actuators`` to test:
+
+       .. code-block:: python
           :caption: check_actuators.py
 
           actuators: [101, 102, 103, 104]
 
-       | Or check ``all`` actuators and ``ignore_actuators``:
+       Or check ``all`` actuators and ``ignore_actuators``:
 
-       .. code-block:: text
+       .. code-block:: python
 
           actuators: all
           ignore_actuators: [333, 412]
 
-   * - Enter engineering mode
+   * - Enter Engineering Mode
      - ``run_command.py``
-     - | .. code-block:: text
-          :caption: run_command.py
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTM1M3
-          cmd: enterEngineering
+        component: MTM1M3
+        cmd: enterEngineering
 
-   * - Exit engineering mode
+   * - Exit Engineering Mode
      - ``run_command.py``
-     - | .. code-block:: text
-          :caption: run_command.py
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-          component: MTM1M3
-          cmd: exitEngineering
+        component: MTM1M3
+        cmd: exitEngineering
 
 
 .. _Simonyi-SAL-Scripts-MTM2:
@@ -145,7 +148,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | ``force: 10``
      - | Write specific actuators in an array to bump test only those:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: check_actuators.py
 
           actuators: [121, 160]
@@ -154,7 +157,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
 
        | Or ignore certain actuators:
 
-       .. code-block:: text
+       .. code-block:: python
 
           ignore_actuators: [333, 412]
 
@@ -183,7 +186,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | ``components: ["M2Hexapod", "CameraHexapod"]``
      - | For M2 Hexapod only:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: enable_hexapod_compensation_mode.py
 
           components:
@@ -191,7 +194,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
        | For Camera Hexapod only:
 
-       .. code-block:: text
+       .. code-block:: python
 
           components:
             - CameraHexapod
@@ -201,7 +204,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        |
        | For Camera Hexapod use ``component: MTHexapod:1``
        | For M2 Hexapod use ``component: MTHexapod:2``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTHexapod:2
@@ -233,7 +236,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | **x, y, z** position in **microns** and **u, v** rotation in **degrees**.
      - | Reset the positions before applying offsets in x, z and u axes:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: offset_camera_hexapod.py
 
           x: 1
@@ -243,19 +246,19 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
        | To reset offsets from all axes:
 
-       .. code-block:: text
+       .. code-block:: python
 
           reset_axes: "all"
 
        | Or to reset only certain axes:
 
-       .. code-block:: text
+       .. code-block:: python
 
           reset_axes: ["x", "z", "u"]
 
    * - Enable Hexapods with new Configuration
      - ``set_summary_state.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: set_summary_state.py
 
           data:
@@ -294,7 +297,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtrotator/move_rotator.py>`__)
        |
        | ``angle`` range [-89, +89]
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: move_rotator.py
 
           angle: -45
@@ -326,7 +329,7 @@ MTMount
        | Requires MTDome to be ``ENABLED`` or ``DISABLED``.
        | Enables **M1M3 force balance system** and M2Hex and Cam Hex **compensation mode**.
        | Offers the option to move to another position and home again.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: home_both_axes.py
 
           final_home_position:
@@ -347,7 +350,7 @@ MTMount
        | If slewing to more than one target, use an array and the ``pause_for`` function.
      - | Az [deg] / El [deg]:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: move_p2p.py
 
           az: 70
@@ -355,21 +358,21 @@ MTMount
 
        | Example for arrays:
 
-       .. code-block:: text
+       .. code-block:: python
 
           az: [70, 90, 110]
           el: [70, 70, 70]
 
        | Or RA [hrs] / Dec [deg]:
 
-       .. code-block:: text
+       .. code-block:: python
 
           ra: 4.59867
           dec: 16.5092
 
        | Array (sexagesimal as strings):
 
-       .. code-block:: text
+       .. code-block:: python
 
           ra: [4.59867, 20.2, "12:20:56.5"]
           dec: [16.5092, 10.1, "-13:34:04.5"]
@@ -383,7 +386,7 @@ MTMount
        | ``target_name: "AzEl"``
        | ``wait_dome: false``
        | ``slew_timeout: 240.0``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: point_azel.py
 
           az: 80
@@ -408,7 +411,7 @@ MTMount
      - | Slew and track ICRS RaDec coordinates.
        | RA in hours (0, 24), DEC in degrees (-90, +90):
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: track_target.py
 
           slew_icrs:
@@ -417,7 +420,7 @@ MTMount
 
        | RA, DEC in sexagesimal (as strings):
 
-       .. code-block:: text
+       .. code-block:: python
 
           slew_icrs:
             ra: "12:20:56.5"
@@ -425,7 +428,7 @@ MTMount
 
        | Slew to AzEl and start tracking:
 
-       .. code-block:: text
+       .. code-block:: python
 
           track_azel:
             az: 65
@@ -433,13 +436,13 @@ MTMount
 
        | Slew and track a target name:
 
-       .. code-block:: text
+       .. code-block:: python
 
           target_name: HD150798
 
        | Find a target based on AzEl and magnitude limit:
 
-       .. code-block:: text
+       .. code-block:: python
 
           find_target:
             az: 65
@@ -464,7 +467,7 @@ MTMount
      - | ``run_command.py``
        |
        | Remember to restore to default, as the settings are cumulative.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           cmd: applySettingsSet
@@ -475,7 +478,7 @@ MTMount
 
    * - Restore to TMA default settings
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           cmd: restoreDefaultSettings
@@ -505,7 +508,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
      - Script Configuration
    * - Issue correction
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTAOS
@@ -513,7 +516,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
    * - Reset correction
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTAOS
@@ -521,7 +524,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
    * - Reset Offset DOF
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTAOS
@@ -532,7 +535,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_aos_closed_loop.py>`__)
        | :file:`disable_aos_closed_loop.py`
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/disable_aos_closed_loop.py>`__)
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: enable_aos_closed_loop.py
 
           used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -552,7 +555,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | ``- mtrotator``
      - | Uses a **previous image**:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: set_dof.py
 
           day: 20250630
@@ -560,7 +563,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
        | Apply **individual dofs** (microns or arcsec):
 
-       .. code-block:: text
+       .. code-block:: python
 
           # Example: M1M3 bending mode 16
           M1M3_B16: 0.3
@@ -574,7 +577,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | [10-29]: M1M3 Bending Modes
        | [30-49]: M2 Bending Modes
 
-       .. code-block:: text
+       .. code-block:: python
 
           dofs: [0.0, 1.0, 2.0, 3.0, 4.0,
           5.0, 6.0, 7.0, 8.0, 9.0,
@@ -588,7 +591,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
      - Same configurations as ``set_dof.py``.
    * - Enable and run closed-loop system on the AOS for LSSTCam
      - :file:`close_loop_lsstcam.py`
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: close_loop_lsstcam.py
 
           exposure_time: 15
@@ -607,14 +610,14 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
      - | If the first image shows a donut rather than a PSF, adjust by hand.
        | Change the camera hexapod z by Dz = [(donut diameter in pixels) * 12] microns.
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: offset_camera_hexapod.py
 
           z: -Dz
 
        | If that makes things worse (bigger donuts):
 
-       .. code-block:: text
+       .. code-block:: python
 
           z: +2 x Dz
 
@@ -628,7 +631,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | ``n_sequences: 1``
        | ``mode: TRIPLET``
        | ``program: AOSSEQUENCE``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: take_aos_sequence_lsstcam.py
 
           filter: z_03
@@ -668,7 +671,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - | :file:`/offset_dome.py`
        |
        | Units of ``az`` in degrees.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: offset_dome.py
 
           offset: 10
@@ -677,7 +680,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - | :file:`/slew_dome.py`
        |
        | Units of ``az`` in degrees.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: slew_dome.py
 
           az: 70
@@ -691,7 +694,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/park_dome.py>`__)
        | :file:`/unpark_dome.py`
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/unpark_dome.py>`__)
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: park_dome.py
 
           ignore:
@@ -712,7 +715,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | mirror covers lost instead of closed).
      - | No configuration, but you can ignore certain CSCs:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: open_dome.py
 
           force: false
@@ -731,7 +734,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - ``run_command.py``
      - | To open:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -739,7 +742,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
 
        | To close:
 
-       .. code-block:: text
+       .. code-block:: python
 
           component: MTDome
           cmd: closeShutter
@@ -755,7 +758,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | **M1**, M2, M3, N1, N2]
        |
        | Bold = louvers available as of 2026-2-14.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -774,7 +777,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        |
        | Alternatively use the ``setLouvers`` command with value 0 in the
        | louver index you want to close.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -787,7 +790,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | DomeAz: ``subSystemIds: 0x1``
        | Dome shutter: ``subSystemIds: 0x4``
        | Louvers: ``subSystemIds: 0x8``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -811,7 +814,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | DomeAz: ``subSystemIds: 0x1``
        | Dome shutter: ``subSystemIds: 0x4``
        | Louvers: ``subSystemIds: 0x8``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -823,7 +826,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - | ``run_command.py``
        |
        | (``exitFault`` will issue a ``resetDrivesAz`` internally; probably not needed)
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -833,7 +836,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
 
    * - Reset Dome shutter drives
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -847,7 +850,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | Required: ``physical_az`` (azimuth position as read by markings).
        |
        | See `Homing MTDome procedure <https://rubinobs.atlassian.net/wiki/spaces/OOD/pages/705003522>`__.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: home_dome.py
 
           physical_az: <physical position as read by markings>
@@ -864,7 +867,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
 
    * - Home Dome shutter
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -878,7 +881,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | Dome operational modes:
        | **1:** Normal mode
        | **2:** Degraded mode
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTDome
@@ -896,7 +899,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        |
        | Default config:
        | ``direction: ClockWise``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: crawl_az.py
 
           direction: CounterClockWise
@@ -944,7 +947,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | Units are microns.
      - | Required for defined focus window — use ``axis``, ``focus_window`` and ``n_steps``:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: focus_sweep_lsstcam.py
 
           axis: z
@@ -956,7 +959,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
        | Or required for chosen steps — use ``axis`` and ``focus_step_sequence``:
 
-       .. code-block:: text
+       .. code-block:: python
 
           axis: "y"
           focus_step_sequence: [200, 50, -50, 200]
@@ -967,7 +970,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
      - | :file:`change_filter_lsstcam.py`
        |
        | Required: ``filter``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: change_filter_lsstcam.py
 
           filter: <filter_name>
@@ -984,25 +987,25 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | ``note:``
        |
        | Required: ``image_type``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: take_image_lsstcam.py
 
           image_type: BIAS
 
-       .. code-block:: text
+       .. code-block:: python
 
           image_type: FLAT
           exp_times: 5
           nimages: 2
           reason: "flat_test"
 
-       .. code-block:: text
+       .. code-block:: python
 
           image_type: ACQ
           exp_times: 1
           program: "BLOCK-TXXXX"
 
-       .. code-block:: text
+       .. code-block:: python
 
           image_type: ENGTEST
           exp_times: 30
@@ -1012,7 +1015,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
      - :file:`track_target_and_take_image_lsstcam.py`
      - | All these are required:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: track_target_and_take_image_lsstcam.py
 
           ra:
@@ -1037,7 +1040,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
        | ``n_sequences: 1``
        | ``mode: TRIPLET``
        | ``program: AOSSEQUENCE``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: take_aos_sequence_lsstcam.py
 
           filter: z_03
@@ -1071,7 +1074,7 @@ LaserTracker
        | ``target: M2`` (REQUIRED)
        |
        | ``target`` options: "M2", "Camera", "CALIBRATION_SCREEN"
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: laser_tracker/align.py
 
           target: CALIBRATION_SCREEN
@@ -1086,7 +1089,7 @@ LaserTracker
 
    * - Park the lasertracker
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: LaserTracker:1
@@ -1113,7 +1116,7 @@ MTCalSys
    * - MTReflector
      - Open/close MTReflector
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: MTReflector
@@ -1132,7 +1135,7 @@ MTCalSys
        | Default config:
        | ``sequence_name: "whitelight_u_source"``
        | ``ignore: ['TunableLaser','LinearStage:104','FiberSpectrograph:101','FiberSpectrograph:102','CBP','Electrometer:102','Electrometer:101']``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: setup_whitelight_flats.py
 
           sequence_name: 'laser_functional'
@@ -1146,7 +1149,7 @@ MTCalSys
        | Default will run for all installed filters:
        | ``sequence_names: ["daily"]``
        | Metadata: ``note``, ``reason``, ``program``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: take_whitelight_flats_lsstcam.py
 
           sequence_names: ['low_level_ptc']
@@ -1160,7 +1163,7 @@ MTCalSys
        | ``azimuth`` and ``elevation`` are float in degrees.
        | Az: [-45.0 to 45.0 deg]
        | El: [-69.0 to 45.0 deg]
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1174,7 +1177,7 @@ MTCalSys
      - | ``run_command.py``
        |
        | There are 5 masks to characterize the beam projection.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1187,7 +1190,7 @@ MTCalSys
      - | ``run_command.py``
        |
        | Rotation is between 1 and 360 deg.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1200,7 +1203,7 @@ MTCalSys
      - | ``run_command.py``
        |
        | Focus in microns. Range is (0, 13000).
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1211,7 +1214,7 @@ MTCalSys
    * -
      - Park CBP (moves to elevation -70, locks the motors)
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1220,7 +1223,7 @@ MTCalSys
    * - Tunable Laser
      - Set tunable laser wavelength
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: TunableLaser
@@ -1233,7 +1236,7 @@ MTCalSys
      - | ``run_command.py``
        |
        | Configurations available: (see XML documentation)
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           cmd: setOpticalConfiguration
@@ -1245,7 +1248,7 @@ MTCalSys
      - | ``run_command.py``
        |
        | Available modes: ``setBurstMode`` and ``setContinuousMode``.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: TunableLaser
@@ -1259,7 +1262,7 @@ MTCalSys
        | Stop cmd: ``stopPropagateLaser``
        |
        | Note: requires setting the mode first.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           component: TunableLaser
@@ -1268,7 +1271,7 @@ MTCalSys
    * -
      - Set laser output to F2 SCU
      - ``run_command.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: run_command.py
 
           cmd: setOpticalConfiguration
@@ -1294,7 +1297,7 @@ Scheduler
        | Properties: ``config`` (string): Name of the configuration .yaml file.
        | This loads the .yaml configuration file and can also be used to
        | state-cycle the scheduler.
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: maintel/scheduler/enable.py
 
           config: <config_file_name>.yaml
@@ -1316,7 +1319,7 @@ Scheduler
        | `here <https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=10064>`__.
      - | e.g. Measurement of Laser Tracker targets:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: maintel/scheduler/add_block.py
 
           id: BLOCK-T89
@@ -1341,7 +1344,7 @@ General Scripts
        | ``MTHexapod:2`` (M2), ``MTM2``, ``MTPtg``, ``MTAOS``, ``MTDome``, ``MTM1M3``
        |
        | States accepted: ``STANDBY``, ``ENABLED``, ``DISABLED``, ``OFFLINE``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: set_summary_state.py
 
           data:
@@ -1349,7 +1352,7 @@ General Scripts
 
        | or:
 
-       .. code-block:: text
+       .. code-block:: python
 
           data:
             -
@@ -1365,7 +1368,7 @@ General Scripts
        |
        | To use an ``ignore`` property:
 
-       .. code-block:: text
+       .. code-block:: python
 
           ignore:
             - mtdometrajectory
@@ -1377,7 +1380,7 @@ General Scripts
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/ensure_onsky_readiness.py>`__)
      - | Default config:
 
-       .. code-block:: text
+       .. code-block:: python
           :caption: ensure_on_sky_readiness.py
 
           slew_flags = ["ACCELERATIONFORCES", "BALANCEFORCES",
@@ -1386,7 +1389,7 @@ General Scripts
 
    * - Enable EAS with different configuration
      - ``set_summary_state.py``
-     - | .. code-block:: text
+     - | .. code-block:: python
           :caption: set_summary_state.py
 
           data:

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -26,6 +26,158 @@ The tables contain the following information:
   Scripts that require empty configurations are labeled as "No Configuration.."
 
 
+.. _Simonyi-SAL-Scripts-General:
+
+General Scripts
+===============
+
+.. list-table::
+   :widths: 20 60 20
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Set Summary State CSC Component
+     - ``set_summary_state.py``
+       
+       .. note::
+        
+        | Available Simonyi Subsystems: 
+        | ``MTMount``, ``MTRotator``, ``MTHexapod:1`` (Cam),
+          ``MTHexapod:2`` (M2), ``MTM2``, ``MTPtg``, ``MTAOS``, ``MTDome``, ``MTM1M3``, ``LSSTCam``
+        |
+        | Available States: 
+        | ``STANDBY``, ``ENABLED``, ``DISABLED``, ``OFFLINE``
+
+     - If we want to send ``MTMount`` to the ``DISABLED`` state:
+     
+       .. code-block:: python
+          :caption: set_summary_state.py
+
+          data:
+            - [MTMount, DISABLED]
+
+       | Or, we can use another format to send ``MTAOS`` to ``STANDBY``:
+
+       .. code-block:: python
+
+          data:
+            -
+              - MTAOS
+              - STANDBY
+
+   * - ``self.group.components`` Naming Convention
+     - 
+       .. note::
+        
+        The name of the CSC must match the name of the CSC in ``group.components``,
+        which is the name of the CSC in *lowercase*, replacing the ":" with "_"
+        for indexed components.
+
+        | Examples:
+        | ``ATMCS`` → ``atmcs``
+        | ``MTHexapod:1`` → ``mthexapod_1``
+
+     - To use an ``ignore`` property in a SAL Script the format is as follows:
+
+       .. code-block:: python
+
+          ignore:
+            - mtdometrajectory
+            - mthexapod_1
+            - mtaos
+       
+       Or, the components can also be written as a list:
+
+       .. code-block:: python
+
+          ignore: [mtdometrajectory, mthexapod_1, mtaos]
+
+
+   * - Check and Prepare Telescope Systems for Observing
+     - | :file:`ensure_on_sky_readiness.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/ensure_onsky_readiness.py>`__)
+     - | Default Configuration:
+
+       .. code-block:: python
+          :caption: ensure_on_sky_readiness.py
+
+          slew_flags = ["ACCELERATIONFORCES", "BALANCEFORCES",
+                        "VELOCITYFORCES", "BOOSTERVALVES"]
+          enable_flags = [True, True, True, False]
+
+   * - Enable EAS with Different Configurations
+     - ``set_summary_state.py``
+
+       .. note::
+
+        | In normal operations, this command is not necessary.
+        | Only perform this task with *approval* from support scientists.
+     - If we want to disable the M1M3 thermal system component of the EAS:
+     
+       .. code-block:: python
+        :caption: set_summary_state.py
+
+        data:
+          - [EAS, STANDBY]
+          - [EAS, ENABLED, "disable_m1m3ts.yaml"]
+
+.. _Simonyi-SAL-Scripts-Scheduler:
+
+Scheduler
+=========
+
+.. list-table::
+   :widths: 20 50 30
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Enable Simonyi Scheduler
+     - :file:`maintel/scheduler/enable.py`
+       
+       .. note::
+        
+        Properties: ``config`` (string): Name of the configuration .yaml file.
+        
+        This loads the .yaml configuration file and can also be used to state-cycle the scheduler.
+
+     - If we want to enable the standard configuration for the LSST survey:
+     
+       .. code-block:: python
+        :caption: maintel/scheduler/enable.py
+
+        config: fbs_config_lsst_survey.yaml
+
+   * - Start Scheduler-Driven Observations
+     - :file:`maintel/scheduler/resume.py`
+     - No Configuration.
+   * - Stop Scheduler-Driven Observations
+     - :file:`maintel/scheduler/stop.py`
+     - No Configuration.
+   * - Start a Testing BLOCK
+     - :file:`maintel/scheduler/add_block.py`
+       
+       .. note::
+        
+        Properties:
+        
+        * ``id`` (string): Name of the BLOCK to be run.
+        * ``override``: List of parameters to be changed/updated in the BLOCK.
+       
+        Current available BLOCKs listed
+        `here <https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=10064>`__.
+
+     - If we wanted to run the initial alignment for Simonyi (BLOCK-T539):
+
+       .. code-block:: python
+          :caption: maintel/scheduler/add_block.py
+
+          id: BLOCK-T539
+
+
 .. _Simonyi-SAL-Scripts-MTM1M3:
 
 MTM1M3
@@ -1372,12 +1524,12 @@ MTCalSys
        
        .. note::
 
-        | The ``azimuth`` and ``elevation`` parameters require floating point numbers measured in *degrees*.
+        | The ``azimuth`` and ``elevation`` parameters require floating point numbers measured in **degrees**.
         |
         | **Limits:**
         | Az: [-45.0 to 45.0 deg]
         | El: [-69.0 to 45.0 deg]
-        
+
      - If we want to move the CBP to *Az = -0.05 deg* and *El = -46.5 deg*:
 
        .. code-block:: python
@@ -1536,134 +1688,6 @@ MTCalSys
         cmd: startPropagateLaser
 
        To stop propagation, set ``cmd: stopPropagateLaser``.
-
-
-.. _Simonyi-SAL-Scripts-Scheduler:
-
-Scheduler
-=========
-
-.. list-table::
-   :widths: 20 50 30
-   :header-rows: 1
-
-   * - Command
-     - SAL Script
-     - Script Configuration
-   * - Enable Simonyi Scheduler
-     - :file:`maintel/scheduler/enable.py`
-       
-       .. note::
-        
-        Properties: ``config`` (string): Name of the configuration .yaml file.
-        
-        This loads the .yaml configuration file and can also be used to state-cycle the scheduler.
-
-     - If we want to enable the standard configuration for the LSST survey:
-     
-       .. code-block:: python
-        :caption: maintel/scheduler/enable.py
-
-        config: fbs_config_lsst_survey.yaml
-
-   * - Start Scheduler-Driven Observations
-     - :file:`maintel/scheduler/resume.py`
-     - No Configuration.
-   * - Stop Scheduler-Driven Observations
-     - :file:`maintel/scheduler/stop.py`
-     - No Configuration.
-   * - Start a Testing BLOCK
-     - :file:`maintel/scheduler/add_block.py`
-       
-       .. note::
-        
-        Properties:
-        
-        * ``id`` (string): Name of the BLOCK to be run.
-        * ``override``: List of parameters to be changed/updated in the BLOCK.
-       
-        Current available BLOCKs listed
-        `here <https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=10064>`__.
-
-     - If we wanted to run the initial alignment for Simonyi (BLOCK-T539):
-
-       .. code-block:: python
-          :caption: maintel/scheduler/add_block.py
-
-          id: BLOCK-T539
-
-
-.. _Simonyi-SAL-Scripts-General:
-
-General Scripts
-===============
-
-.. list-table::
-   :widths: 20 40 40
-   :header-rows: 1
-
-   * - Command
-     - SAL Script
-     - Script Configuration
-   * - Set Summary State to OFFLINE/ENABLED/DISABLED/STANDBY
-     - | ``set_summary_state.py``
-       |
-       | Subsystems accepted: ``MTMount``, ``MTRotator``, ``MTHexapod:1`` (Cam),
-       | ``MTHexapod:2`` (M2), ``MTM2``, ``MTPtg``, ``MTAOS``, ``MTDome``, ``MTM1M3``
-       |
-       | States accepted: ``STANDBY``, ``ENABLED``, ``DISABLED``, ``OFFLINE``
-     - | .. code-block:: python
-          :caption: set_summary_state.py
-
-          data:
-            - [MTMount, DISABLED]
-
-       | or:
-
-       .. code-block:: python
-
-          data:
-            -
-              - MTAOS
-              - STANDBY
-
-   * - self.group.components naming convention
-     - | The name of the CSC must match the name of the CSC in ``group.components``,
-       | which is the name of the CSC in lowercase, replacing the ":" with "_"
-       | for indexed components.
-     - | e.g. ``ATMCS`` → ``atmcs``
-       | ``MTHexapod:1`` → ``hexapod_1``
-       |
-       | To use an ``ignore`` property:
-
-       .. code-block:: python
-
-          ignore:
-            - mtdometrajectory
-            - hexapod_1
-            - mtaos
-
-   * - Checks and prepares key telescope systems
-     - | :file:`ensure_on_sky_readiness.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/ensure_onsky_readiness.py>`__)
-     - | Default Configuration:
-
-       .. code-block:: python
-          :caption: ensure_on_sky_readiness.py
-
-          slew_flags = ["ACCELERATIONFORCES", "BALANCEFORCES",
-            "VELOCITYFORCES", "BOOSTERVALVES"]
-          enable_flags = [True, True, True, False]
-
-   * - Enable EAS with different configuration
-     - ``set_summary_state.py``
-     - | .. code-block:: python
-          :caption: set_summary_state.py
-
-          data:
-            - [EAS, STANDBY]
-            - [EAS, ENABLED, "disable_m1m3ts.yaml"]
-
 
 This procedure was last modified on |today|.
 

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -1173,41 +1173,57 @@ LaserTracker
    * - Command
      - SAL Script
      - Script Configuration
-   * - Align the TMA to the calibration screen
-     - | :file:`laser_tracker/align.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/laser_tracker/align.py>`__)
+   * - Align the TMA to the Calibration Screen
+     - | :file:`laser_tracker/align.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/laser_tracker/align.py>`__]
        |
        | Default Configuration:
-       | ``max_iter: 10``
-       | ``tolerance_linear: 0.0001`` (meters)
-       | ``tolerance_angular: 0.00138`` (deg, ~5 arcsec)
-       | ``target: M2`` (REQUIRED)
-       |
-       | ``target`` options: "M2", "Camera", "CALIBRATION_SCREEN"
-     - | .. code-block:: python
-          :caption: laser_tracker/align.py
 
-          target: CALIBRATION_SCREEN
-          tolerance_angular: 0.01
-          reason: "Align TMA to Calibration Screen"
-          program: "BLOCK-T495"
+       .. code-block:: python
+        
+        max_iter: 10
+        tolerance_linear: 0.0001 # in meters
+        tolerance_angular: 0.00138 # in deg (~5 arcsec)
+        target: "M2" 
+        # Target Options (REQUIRED): 
+        # "M2", "Camera", or "CALIBRATION_SCREEN"
 
        .. note::
+        
+        The LaserTracker alignment of the Calibration Screen is now done by
+        using ``id: BLOCK-T495`` in the :ref:`scheduler/add_block.py <Simonyi-SAL-Scripts-Scheduler>` script.
 
-          The LaserTracker Measurement of the Calibration screen is done now
-          using ``id: BLOCK-T495``.
+        
+     - To align to the calibration screen with a 0.01 deg angular tolerance:
+       
+       .. code-block:: python
+        :caption: laser_tracker/align.py
 
-   * - Park the lasertracker
+        target: CALIBRATION_SCREEN
+        tolerance_angular: 0.01
+        reason: "Align TMA to Calibration Screen"
+        program: "BLOCK-T495"
+
+       
+   * - Park the LaserTracker
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
 
-          component: LaserTracker:1
-          cmd: measurePoint
-          parameters:
-            collection: A
-            pointgroup: M1M3
-            target: p2
+       .. note::
+        
+        The LaserTracker parking command is now done by
+        using ``id: BLOCK-T495`` in the :ref:`scheduler/add_block.py <Simonyi-SAL-Scripts-Scheduler>` script.
+
+     - To park the lasertracker at the p2 point on M1M3:
+
+       .. code-block:: python
+        :caption: run_command.py
+
+        component: LaserTracker:1
+        cmd: measurePoint
+        parameters:
+          collection: A
+          pointgroup: M1M3
+          target: p2
+
 
 
 .. _Simonyi-SAL-Scripts-MTCalSys:

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -290,17 +290,17 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Command
      - SAL Script
      - Script Configuration
-   * - Move rotator to specific angle
-     - | :file:`/move_rotator.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtrotator/move_rotator.py>`__)
+   * - Move Rotator Angle
+     - | :file:`/move_rotator.py` (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtrotator/move_rotator.py>`__)
        |
-       | ``angle`` range [-89, +89]
-     - | .. code-block:: python
-          :caption: move_rotator.py
+       | ``angle`` range: [-89, +89] degrees.
+     - 
+       .. code-block:: python
+        :caption: move_rotator.py
 
-          angle: -45
+        angle: -45
 
-   * - Stop rotator
+   * - Stop Rotator
      - :file:`stop_rotator.py`
      - No configuration
 

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -32,7 +32,6 @@ General Scripts
 ===============
 
 .. list-table::
-   :widths: 20 60 20
    :header-rows: 1
 
    * - Command
@@ -50,22 +49,25 @@ General Scripts
         | Available States: 
         | ``STANDBY``, ``ENABLED``, ``DISABLED``, ``OFFLINE``
 
-     - If we want to send ``MTMount`` to the ``DISABLED`` state:
+     - 
+       .. dropdown:: SAL Script
+
+        If we want to send ``MTMount`` to the ``DISABLED`` state:
      
-       .. code-block:: python
-          :caption: set_summary_state.py
+        .. code-block:: python
+           :caption: set_summary_state.py
 
-          data:
-            - [MTMount, DISABLED]
+           data:
+             - [MTMount, DISABLED]
 
-       | Or, we can use another format to send ``MTAOS`` to ``STANDBY``:
+        | Or, we can use another format to send ``MTAOS`` to ``STANDBY``:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          data:
-            -
-              - MTAOS
-              - STANDBY
+           data:
+             -
+               - MTAOS
+               - STANDBY
 
    * - ``self.group.components`` Naming Convention
      - 
@@ -79,33 +81,39 @@ General Scripts
         | ``ATMCS`` → ``atmcs``
         | ``MTHexapod:1`` → ``mthexapod_1``
 
-     - To use an ``ignore`` property in a SAL Script the format is as follows:
+     - 
+       .. dropdown:: SAL Script
+        
+        To use an ``ignore`` property in a SAL Script the format is as follows:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          ignore:
-            - mtdometrajectory
-            - mthexapod_1
-            - mtaos
+           ignore:
+             - mtdometrajectory
+             - mthexapod_1
+             - mtaos
        
-       Or, the components can also be written as a list:
+        Or, the components can also be written as a list:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          ignore: [mtdometrajectory, mthexapod_1, mtaos]
+           ignore: [mtdometrajectory, mthexapod_1, mtaos]
 
 
    * - Check and Prepare Telescope Systems for Observing
      - | :file:`ensure_on_sky_readiness.py`
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/ensure_onsky_readiness.py>`__)
-     - | Default Configuration:
+     - 
+       .. dropdown:: SAL Script
+        
+        Default Configuration:
 
-       .. code-block:: python
-          :caption: ensure_on_sky_readiness.py
+        .. code-block:: python
+           :caption: ensure_on_sky_readiness.py
 
-          slew_flags = ["ACCELERATIONFORCES", "BALANCEFORCES",
+           slew_flags = ["ACCELERATIONFORCES", "BALANCEFORCES",
                         "VELOCITYFORCES", "BOOSTERVALVES"]
-          enable_flags = [True, True, True, False]
+           enable_flags = [True, True, True, False]
 
    * - Enable EAS with Different Configurations
      - ``set_summary_state.py``
@@ -114,14 +122,17 @@ General Scripts
 
         | In normal operations, this command is not necessary.
         | Only perform this task with *approval* from support scientists.
-     - If we want to disable the M1M3 thermal system component of the EAS:
+     - 
+       .. dropdown:: SAL Script
+        
+        If we want to disable the M1M3 thermal system component of the EAS:
      
-       .. code-block:: python
-        :caption: set_summary_state.py
+        .. code-block:: python
+         :caption: set_summary_state.py
 
-        data:
-          - [EAS, STANDBY]
-          - [EAS, ENABLED, "disable_m1m3ts.yaml"]
+         data:
+           - [EAS, STANDBY]
+           - [EAS, ENABLED, "disable_m1m3ts.yaml"]
 
 .. _Simonyi-SAL-Scripts-Scheduler:
 
@@ -129,7 +140,6 @@ Scheduler
 =========
 
 .. list-table::
-   :widths: 20 50 30
    :header-rows: 1
 
    * - Command
@@ -144,12 +154,15 @@ Scheduler
         
         This loads the .yaml configuration file and can also be used to state-cycle the scheduler.
 
-     - If we want to enable the standard configuration for the LSST survey:
+     - 
+       .. dropdown:: SAL Script
+        
+        If we want to enable the standard configuration for the LSST survey:
      
-       .. code-block:: python
-        :caption: maintel/scheduler/enable.py
+        .. code-block:: python
+         :caption: maintel/scheduler/enable.py
 
-        config: fbs_config_lsst_survey.yaml
+         config: fbs_config_lsst_survey.yaml
 
    * - Start Scheduler-Driven Observations
      - :file:`maintel/scheduler/resume.py`
@@ -170,12 +183,15 @@ Scheduler
         Current available BLOCKs listed
         `here <https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=10064>`__.
 
-     - If we wanted to run the initial alignment for Simonyi (BLOCK-T539):
+     - 
+       .. dropdown:: SAL Script
+        
+        If we wanted to run the initial alignment for Simonyi (BLOCK-T539):
 
-       .. code-block:: python
-          :caption: maintel/scheduler/add_block.py
+        .. code-block:: python
+           :caption: maintel/scheduler/add_block.py
 
-          id: BLOCK-T539
+           id: BLOCK-T539
 
 
 .. _Simonyi-SAL-Scripts-MTM1M3:
@@ -198,15 +214,18 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - No Configuration.
    * - Slew Flags
      - :file:`/enable_m1m3_slew_controller_flags.py`
-     - Configuration for normal operations:
+     - 
+       .. dropdown:: SAL Script
+        
+        Configuration for normal operations:
 
-       .. code-block:: python
-        :caption: enable_m1m3_slew_controller_flags.py
+        .. code-block:: python
+         :caption: enable_m1m3_slew_controller_flags.py
 
-        slew_flags: [ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES, BOOSTERVALVES]
-        enable: [True, True, True, True]
+         slew_flags: [ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES, BOOSTERVALVES]
+         enable: [True, True, True, True]
 
-       To disable a specific slew flag, change the appropriate boolean to ``False``.
+        To disable a specific slew flag, change the appropriate boolean to ``False``.
 
    * - Enable/Disable Force Balance System
      - | :file:`/enable_m1m3_balance_system.py`
@@ -223,12 +242,15 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           
           hardpoints: all
 
-     - To check specific hardpoints:
+     - 
+       .. dropdown:: SAL Script
+        
+        To check specific hardpoints:
 
-       .. code-block:: python
-          :caption: check_hardpoint.py
+        .. code-block:: python
+           :caption: check_hardpoint.py
 
-          hardpoints: [1, 2, 4]
+           hardpoints: [1, 2, 4]
 
    * - M1M3 Bump Test Any/All Actuators
      - :file:`/check_actuators.py`
@@ -242,37 +264,44 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           actuators: all
           ignore_actuators: []
 
-     - Provide a list of the ``actuators`` to test:
+     - 
+       .. dropdown:: SAL Script
+        
+        Provide a list of the ``actuators`` to test:
 
-       .. code-block:: python
-          :caption: check_actuators.py
+        .. code-block:: python
+           :caption: check_actuators.py
 
-          actuators: [101, 102, 103, 104]
+           actuators: [101, 102, 103, 104]
 
-       Or check ``all`` actuators and ``ignore_actuators``:
+        Or check ``all`` actuators and ``ignore_actuators``:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          actuators: all
-          ignore_actuators: [333, 412]
+           actuators: all
+           ignore_actuators: [333, 412]
 
    * - Enter Engineering Mode
      - ``run_command.py``
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTM1M3
-        cmd: enterEngineering
+          component: MTM1M3
+          cmd: enterEngineering
 
    * - Exit Engineering Mode
      - ``run_command.py``
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTM1M3
-        cmd: exitEngineering
+          component: MTM1M3
+          cmd: exitEngineering
 
 
 .. _Simonyi-SAL-Scripts-MTM2:
@@ -307,20 +336,23 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
           period: 60
           force: 10
 
-     - Write specific actuators in an array to bump test only those:
+     - 
+       .. dropdown:: SAL Script
+        
+        Write specific actuators in an array to bump test only those:
 
-       .. code-block:: python
-          :caption: check_actuators.py
+        .. code-block:: python
+           :caption: check_actuators.py
 
-          actuators: [121, 160]
-          period: 5
-          force: 10
+           actuators: [121, 160]
+           period: 5
+           force: 10
 
-       Or ignore certain actuators:
+        Or ignore certain actuators:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          ignore_actuators: [333, 412]
+           ignore_actuators: [333, 412]
 
 
 .. _Simonyi-SAL-Scripts-MTHexapods:
@@ -349,20 +381,23 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
         
           components: ["M2Hexapod", "CameraHexapod"]
 
-     - For M2 Hexapod only:
+     - 
+       .. dropdown:: SAL Script
+        
+        For M2 Hexapod only:
 
-       .. code-block:: python
-          :caption: enable_hexapod_compensation_mode.py
+        .. code-block:: python
+           :caption: enable_hexapod_compensation_mode.py
 
-          components:
-            - M2Hexapod
+           components:
+             - M2Hexapod
 
-       For Camera Hexapod only:
+        For Camera Hexapod only:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          components:
-            - CameraHexapod
+           components:
+             - CameraHexapod
 
    * - Reset M2/Camera Hexapod Positions
      - ``run_command.py``
@@ -373,20 +408,22 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
         For M2 Hexapod use ``component: MTHexapod:2``
 
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTHexapod:2
-        cmd: move
-        parameters:
-            x: 0
-            y: 0
-            z: 0
-            u: 0
-            v: 0
-            w: 0
+          component: MTHexapod:2
+          cmd: move
+          parameters:
+              x: 0
+              y: 0
+              z: 0
+              u: 0
+              v: 0
+              w: 0
 
-       | **x, y, z** position in **microns** and **u, v, w** rotation in **degrees**.
+        **x, y, z** position in **microns** and **u, v, w** rotation in **degrees**.
 
    * - Offset M2/Camera Hexapods
      - | :file:`offset_camera_hexapod.py`
@@ -397,49 +434,59 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
         | **Properties:** ``x``, ``y``, ``z``, ``u``, ``v``, and ``reset_axes``.
         | **x, y, z** position in **microns** and **u, v** rotation in **degrees**.
 
-     - | Reset the positions before applying offsets in x, z and u axes:
+     - 
+       .. dropdown:: SAL Script
+        
+        Reset the positions before applying offsets in x, z and u axes:
 
-       .. code-block:: python
-          :caption: offset_camera_hexapod.py
+        .. code-block:: python
+           :caption: offset_camera_hexapod.py
 
-          x: 1
-          z: 3
-          u: 0.23
-          reset_axes: true
+           x: 1
+           z: 3
+           u: 0.23
+           reset_axes: true
 
-       | To reset offsets from all axes:
+        To reset offsets from all axes:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          reset_axes: "all"
+           reset_axes: "all"
 
-       | Or to reset only certain axes:
+        Or to reset only certain axes:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          reset_axes: ["x", "z", "u"]
+           reset_axes: ["x", "z", "u"]
 
    * - Change Hexapod YAML Configuration
      - ``set_summary_state.py``
-     - 
-       .. code-block:: python
-        :caption: set_summary_state.py
 
-        data:
-          -
-            - MTHexapod:1
-            - Standby
-          -
-            - MTHexapod:1
-            - Enabled
-            - laser_rotation_elevation_v18.yaml
-          -
-            - MTHexapod:2
-            - Standby
-          -
-            - MTHexapod:2
-            - Enabled
-            - laser_rotation_elevation_v18.yaml
+       .. note::
+
+        | In normal operations, this command is not necessary.
+        | Only perform this task with *approval* from support scientists.
+     - 
+       .. dropdown:: SAL Script
+        
+        .. code-block:: python
+          :caption: set_summary_state.py
+
+          data:
+            -
+              - MTHexapod:1
+              - Standby
+            -
+              - MTHexapod:1
+              - Enabled
+              - laser_rotation_elevation_v18.yaml
+            -
+              - MTHexapod:2
+              - Standby
+            -
+              - MTHexapod:2
+              - Enabled
+              - laser_rotation_elevation_v18.yaml
 
 
 .. _Simonyi-SAL-Scripts-MTRotator:
@@ -462,12 +509,15 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        .. note::
 
         ``angle`` range: [-89, +89] degrees.
-     - To move the rotator to -45 deg:
+     - 
+       .. dropdown:: SAL Script
+        
+        To move the rotator to -45 deg:
   
-       .. code-block:: python
-        :caption: move_rotator.py
+        .. code-block:: python
+         :caption: move_rotator.py
 
-        angle: -45
+         angle: -45
 
    * - Stop Rotator
      - :file:`stop_rotator.py`
@@ -499,17 +549,20 @@ MTMount
         | Script enables **M1M3 force balance system** and M2Hex and Cam Hex **compensation mode**.
         | It also offers the option to move to another position and home again.
 
-     - To home both axes at the position *Az = 1 deg* and *El = 46 deg*:
+     - 
+       .. dropdown:: SAL Script 
+        
+        To home both axes at the position *Az = 1 deg* and *El = 46 deg*:
 
-       .. code-block:: python
-        :caption: home_both_axes.py
+        .. code-block:: python
+         :caption: home_both_axes.py
 
-        final_home_position:
-          az: 1
-          el: 46
+         final_home_position:
+           az: 1
+           el: 46
 
-       The position (Az: 1, El: 46) was chosen to be run every time we home the axes, 
-       to avoid offsets inconsistency when homing at different positions.
+        The position (Az: 1, El: 46) was chosen to be run every time we home the axes, 
+        to avoid offsets inconsistency when homing at different positions.
 
    * - Move TMA Point-to-Point
      - | :file:`{p1}/move_p2p.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/move_p2p.py>`__]
@@ -523,36 +576,39 @@ MTMount
           pause_for: 0
           move_timeout: 120.0
        
-     - Select a single point in Az (deg), El (deg) or in RA (hrs), Dec (deg):
-
-       .. code-block:: python
-          :caption: move_p2p.py
-
-          az: 70
-          el: 70
-
-       .. code-block:: python
-
-          ra: 4.59867
-          dec: 16.5092
-
-       If slewing to more than one target, use an array and the ``pause_for`` function.
-
-       .. code-block:: python
-
-          az: [70, 90, 110]
-          el: [70, 70, 70]
-          pause_for: 30
-
-       .. code-block:: python
-
-          ra: [4.59867, 20.2, "12:20:56.5"]
-          dec: [16.5092, 10.1, "-13:34:04.5"]
-          pause_for: 15
-
-       .. note::
+     - 
+       .. dropdown:: SAL Script
         
-        For (RA, Dec) arrays, sexagesimals may be added as strings.
+        Select a single point in Az (deg), El (deg) or in RA (hrs), Dec (deg):
+
+        .. code-block:: python
+           :caption: move_p2p.py
+
+           az: 70
+           el: 70
+
+        .. code-block:: python
+
+           ra: 4.59867
+           dec: 16.5092
+
+        If slewing to more than one target, use an array and the ``pause_for`` function.
+
+        .. code-block:: python
+
+           az: [70, 90, 110]
+           el: [70, 70, 70]
+           pause_for: 30
+
+        .. code-block:: python
+
+           ra: [4.59867, 20.2, "12:20:56.5"]
+           dec: [16.5092, 10.1, "-13:34:04.5"]
+           pause_for: 15
+
+        .. note::
+        
+         For (RA, Dec) arrays, sexagesimals may be added as strings.
 
    * - Point (Az, El)
      - :file:`{p1}/point_azel.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_point_azel.py>`__]
@@ -568,13 +624,16 @@ MTMount
           wait_dome: false
           slew_timeout: 240.0
 
-     - To point the telescope at *Az = 80 deg* and *El = 80 deg*:
+     - 
+       .. dropdown:: SAL Script
+        
+        To point the telescope at *Az = 80 deg* and *El = 80 deg*:
 
-       .. code-block:: python
-        :caption: point_azel.py
+        .. code-block:: python
+         :caption: point_azel.py
 
-        az: 80
-        el: 80
+         az: 80
+         el: 80
 
    * - Track Target
      - :file:`{p1}/track_target.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_track_target.py>`__]
@@ -599,46 +658,49 @@ MTMount
 
        
        
-     - | Slew and track ICRS RA, Dec coordinates.
-       | RA in hours (0, 24), DEC in degrees (-90, +90):
+     - 
+       .. dropdown:: SAL Script
+        
+        | Slew and track ICRS RA, Dec coordinates.
+        | RA in hours (0, 24), DEC in degrees (-90, +90):
 
-       .. code-block:: python
-          :caption: track_target.py
+        .. code-block:: python
+           :caption: track_target.py
 
-          slew_icrs:
-            ra: 20.2
-            dec: 10.1
+           slew_icrs:
+             ra: 20.2
+             dec: 10.1
 
-       | RA, DEC in sexagesimals (as strings):
+        | RA, DEC in sexagesimals (as strings):
 
-       .. code-block:: python
+        .. code-block:: python
 
-          slew_icrs:
-            ra: "12:20:56.5"
-            dec: "-13:34:04.5"
+           slew_icrs:
+             ra: "12:20:56.5"
+             dec: "-13:34:04.5"
 
-       | Slew to Az, El and start tracking:
+        | Slew to Az, El and start tracking:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          track_azel:
-            az: 65
-            el: 45
+           track_azel:
+             az: 65
+             el: 45
 
-       | Slew and track a target name:
+        | Slew and track a target name:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          target_name: HD150798
+           target_name: HD150798
 
-       | Find a target based on AzEl and magnitude limit:
+        | Find a target based on AzEl and magnitude limit:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          find_target:
-            az: 65
-            el: 25
-            mag_limit: 8
+           find_target:
+             az: 65
+             el: 25
+             mag_limit: 8
 
    * - Stop Telescope Tracking
      - | :file:`{p1}/stop_tracking.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_stop_tracking.py>`__]
@@ -661,25 +723,30 @@ MTMount
         
         Remember to restore to default, as the settings are cumulative.
 
-     - To set MTMount to 10% performance settings:
+     - 
+       .. dropdown:: run_command.py
+        
+        To set MTMount to 10% performance settings:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+          :caption: run_command.py
 
-        cmd: applySettingsSet
-        component: MTMount
-        parameters:
-          restoreDefaults: true
-          settings: 10percentperformance
+          cmd: applySettingsSet
+          component: MTMount
+          parameters:
+            restoreDefaults: true
+            settings: 10percentperformance
 
    * - Restore TMA to Default Settings
      - ``run_command.py``
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTMount
-        cmd: restoreDefaultSettings
+          component: MTMount
+          cmd: restoreDefaultSettings
 
    * - Unpark Mount
      - :file:`{p2}/unpark_mount.py`
@@ -712,49 +779,58 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
    * - Issue MTAOS Correction
      - ``run_command.py``
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTAOS
-        cmd: issueCorrection
+          component: MTAOS
+          cmd: issueCorrection
 
    * - Reset MTAOS Correction
      - ``run_command.py``
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTAOS
-        cmd: resetCorrection
+          component: MTAOS
+          cmd: resetCorrection
 
    * - Reset Applied Offsets to Degrees of Freedom (DOF)
      - ``run_command.py``
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTAOS
-        cmd: resetOffsetDOF
+          component: MTAOS
+          cmd: resetOffsetDOF
 
    * - Enable/Disable AOS closed-loop
      - | :file:`enable_aos_closed_loop.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_aos_closed_loop.py>`__]
        | :file:`disable_aos_closed_loop.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/disable_aos_closed_loop.py>`__]
-     - Default Configuration:
-       
-       .. code-block:: python
-        :caption: enable_aos_closed_loop.py
+     - 
+       .. dropdown:: SAL Script
         
-        truncation_index: 12
-        used_dofs: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,30,31,32,33,34]
+        Default Configuration:
        
-       Higher selectivity of DOFs, truncation, zernikes, etc. 
-       can be done, with the approval of the AOS team:
+        .. code-block:: python
+         :caption: enable_aos_closed_loop.py
+        
+         truncation_index: 12
+         used_dofs: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,30,31,32,33,34]
        
-       .. code-block:: python
+        Higher selectivity of DOFs, truncation, zernikes, etc. 
+        can be done, with the approval of the AOS team:
+       
+        .. code-block:: python
 
-        used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        truncation_index: [2]
-        zn_selected: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22, 27, 28]
+         used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+         truncation_index: [2]
+         zn_selected: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22, 27, 28]
 
    * - Set Telescope DOFs
      - :file:`set_dof.py`
@@ -771,76 +847,85 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
             - mthexapod_2
             - mtrotator
 
-     - Select DOFs from a **previous image**:
+     - 
+       .. dropdown:: SAL Script
+        
+        Select DOFs from a **previous image**:
 
-       .. code-block:: python
-          :caption: set_dof.py
+        .. code-block:: python
+           :caption: set_dof.py
 
-          day: 20250630
-          seq: 457
+           day: 20250630
+           seq: 457
 
-       Apply **individual DOFs** (microns or arcsec):
+        Apply **individual DOFs** (microns or arcsec):
 
-       .. code-block:: python
+        .. code-block:: python
 
-          # Example: M1M3 bending mode 16
-          M1M3_B16: 0.3
+           # Example: M1M3 bending mode 16
+           M1M3_B16: 0.3
 
-          # Example: M2 hexapod offset in x
-          M2_dx: 5
+           # Example: M2 hexapod offset in x
+           M2_dx: 5
 
-       Apply **multiple DOFs** (50-dimensional vector):
+        Apply **multiple DOFs** (50-dimensional vector):
        
-       * [0-4]: M2 Rigid Body Motions
-       * [5-9]: Camera Rigid Body Motions
-       * [10-29]: M1M3 Bending Modes
-       * [30-49]: M2 Bending Modes
+        * [0-4]: M2 Rigid Body Motions
+        * [5-9]: Camera Rigid Body Motions
+        * [10-29]: M1M3 Bending Modes
+        * [30-49]: M2 Bending Modes
 
-       .. code-block:: python
+        .. code-block:: python
 
-          dofs: [0.0, 1.0, 2.0, 3.0, 4.0,
-                 5.0, 6.0, 7.0, 8.0, 9.0,
-                 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0,
-                 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
-                 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0,
-                 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0]
+           dofs: [0.0, 1.0, 2.0, 3.0, 4.0,
+                  5.0, 6.0, 7.0, 8.0, 9.0,
+                  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0,
+                  20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
+                  30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0,
+                  40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0]
 
    * - Apply DOFs to Telescope
      - :file:`apply_dof.py`
      - Same configurations as ``set_dof.py``.
    * - Run Closed-Loop System on AOS
      - :file:`close_loop_lsstcam.py`
-     - Higher selectivity of script parameters can be done, with the approval of the AOS team.
+     - 
+      .. dropdown:: SAL Script
+        
+        Higher selectivity of script parameters can be done, with the approval of the AOS team.
 
-       .. code-block:: python
-        :caption: close_loop_lsstcam.py
+        .. code-block:: python
+         :caption: close_loop_lsstcam.py
 
-        exposure_time: 15
-        max_iter: 5
-        mode: "FAM"
-        program: "BLOCK-T249"
-        note: "initial_focus_dzs_tilts_bending_modes"
-        used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, 28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 45, 46]
-        apply_corrections: true
-        use_ocps: true
-        filter: "r_03"
+         exposure_time: 15
+         max_iter: 5
+         mode: "FAM"
+         program: "BLOCK-T249"
+         note: "initial_focus_dzs_tilts_bending_modes"
+         used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, 28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 45, 46]
+         apply_corrections: true
+         use_ocps: true
+         filter: "r_03"
 
    * - Offset M2/Camera Hexapods (PSF Focus)
      - | :file:`offset_m2_hexapod.py`
        | :file:`offset_camera_hexapod.py`
-     - | If the first image shows a donut rather than a PSF, adjust by hand.
-       | Change the camera hexapod z by **Dz = [(donut diameter in pixels) * 12]** microns.
+     - 
+       .. dropdown:: SAL Script
+        
+        | If the first image shows a donut rather than a PSF, adjust by hand.
+        | Change the camera hexapod z by **Dz = [(donut diameter in pixels) * 12]** microns.
 
-       .. code-block:: python
-          :caption: offset_camera_hexapod.py
+        .. code-block:: python
+           :caption: offset_camera_hexapod.py
 
-          z: -Dz
+           z: -Dz
 
-       | If that makes things worse (bigger donuts):
+        | If that makes things worse (bigger donuts):
 
-       .. code-block:: python
+        .. code-block:: python
 
-          z: +2 x Dz
+           z: +2 x Dz
 
    * - Take Triplet Sequence with LSSTCam
      - :file:`take_aos_sequence_lsstcam.py`
@@ -858,17 +943,20 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
           mode: TRIPLET
           program: AOSSEQUENCE
 
-     - The following is an example AOS sequence used in testing:
+     - 
+       .. dropdown:: SAL Script
+        
+        The following is an example AOS sequence used in testing:
        
-       .. code-block:: python
-        :caption: take_aos_sequence_lsstcam.py
+        .. code-block:: python
+         :caption: take_aos_sequence_lsstcam.py
 
-        filter: z_20
-        exposure_time: 10
-        dz: 800
-        mode: TRIPLET
-        program: AOSSEQUENCE
-        reason: "test"
+         filter: z_20
+         exposure_time: 10
+         dz: 800
+         mode: TRIPLET
+         program: AOSSEQUENCE
+         reason: "test"
 
 
 .. _Simonyi-SAL-Scripts-MTDome:
@@ -897,42 +985,51 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - No Configuration.
    * - Offset Dome Azimuth
      - :file:`/offset_dome.py`
-     - Units of ``az`` in degrees.
+     - 
+       .. dropdown:: SAL Script
+        
+        Units of ``az`` in degrees.
 
-       .. code-block:: python
-        :caption: offset_dome.py
+        .. code-block:: python
+         :caption: offset_dome.py
 
-        offset: 10
+         offset: 10
 
    * - Slew Dome in Azimuth
      - :file:`/slew_dome.py`
-     - | Units of ``az`` in degrees. 
-       | If needed, CSC components can be ignored with the ``ignore`` parameter.
+     - 
+       .. dropdown:: SAL Script
+        
+        | Units of ``az`` in degrees. 
+        | If needed, CSC components can be ignored with the ``ignore`` parameter.
 
-       .. code-block:: python
-        :caption: slew_dome.py
+        .. code-block:: python
+         :caption: slew_dome.py
 
-        az: 70
-        ignore:
-          - mtmount
-          - mthexapod_1
-          - mthexapod_2
+         az: 70
+         ignore:
+           - mtmount
+           - mthexapod_1
+           - mthexapod_2
 
    * - Park/Unpark Dome
      - | :file:`/park_dome.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/park_dome.py>`__]
        | :file:`/unpark_dome.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/unpark_dome.py>`__]
-     - If needed, CSC components can be ignored with the ``ignore`` parameter. 
+     - 
+       .. dropdown:: SAL Script
+        
+        If needed, CSC components can be ignored with the ``ignore`` parameter. 
      
-       .. code-block:: python
-        :caption: park_dome.py
+        .. code-block:: python
+         :caption: park_dome.py
 
-        ignore:
-          - mtm1m3
-          - mtm2
-          - mtaos
-          - mtdometrajectory
-          - mthexapod_1
-          - mthexapod_2
+         ignore:
+           - mtm1m3
+           - mtm2
+           - mtaos
+           - mtdometrajectory
+           - mthexapod_1
+           - mthexapod_2
 
    * - Open/Close MTDome
      - | :file:`/open_dome.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/open_dome.py>`__]
@@ -947,37 +1044,40 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
         The dome can also open/close via a direct override using a ``run_command.py`` script,
         if the normal SAL Script fails to execute properly.
 
-     - No Configuration., but you can ignore CSCs with the ``ignore`` parameter:
+     - 
+       .. dropdown:: SAL Script
+        
+        No Configuration., but you can ignore CSCs with the ``ignore`` parameter:
 
-       .. code-block:: python
-          :caption: open_dome.py
+        .. code-block:: python
+           :caption: open_dome.py
 
-          force: false
-          ignore:
-            - mtm1m3
-            - mtm2
-            - mtaos
-            - mtdometrajectory
-            - mthexapod_1
-            - mthexapod_2
-            - mtmount
-            - mtptg
-            - mtrotator
+           force: false
+           ignore:
+             - mtm1m3
+             - mtm2
+             - mtaos
+             - mtdometrajectory
+             - mthexapod_1
+             - mthexapod_2
+             - mtmount
+             - mtptg
+             - mtrotator
       
-       To open the dome with a ``run_command.py``:
+        To open the dome with a ``run_command.py``:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: MTDome
-          cmd: openShutter
+           component: MTDome
+           cmd: openShutter
 
-       To close the dome with a ``run_command.py``:
+        To close the dome with a ``run_command.py``:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          component: MTDome
-          cmd: closeShutter
+           component: MTDome
+           cmd: closeShutter
 
    * - Open/Close Dome Louvers
      - ``run_command.py``
@@ -991,32 +1091,35 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
          **E1**, **E2**, E3, F1, F2, F3, G1, G2, G3, **H1**, **H2**, 
          H3, I1, I2, I3, L1, L2, L3, **M1**, M2, M3, N1, N2]
 
-     - If one wants to open the mechanical louvers **highlighted in bold** in the *Louver Index*:
+     - 
+       .. dropdown:: run_command.py
+        
+        If one wants to open the mechanical louvers **highlighted in bold** in the *Louver Index*:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: MTDome
-          cmd: setLouvers
-          parameters:
-            position: [0.0, 0.0, 100.0, 0.0, 0.0,
-                       0.0, 0.0, 0.0, 0.0, 0.0,
-                       0.0, 100.0, 100.0, 0.0, 0.0,
-                       0.0, 0.0, 0.0, 0.0, 0.0,
-                       100.0, 100.0, 0.0, 0.0, 0.0,
-                       0.0, 0.0, 0.0, 0.0, 100.0,
-                       0.0, 0.0, 0.0, 0.0]
+           component: MTDome
+           cmd: setLouvers
+           parameters:
+             position: [0.0, 0.0, 100.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0, 0.0, 0.0,
+                        0.0, 100.0, 100.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0, 0.0, 0.0,
+                        100.0, 100.0, 0.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0, 0.0, 100.0,
+                        0.0, 0.0, 0.0, 0.0]
     
-       To close all louvers:
+        To close all louvers:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: MTDome
-          cmd: closeLouvers
+           component: MTDome
+           cmd: closeLouvers
 
-       Alternatively, one can use the ``setLouvers`` command with value 0 in the
-       louver indices to close specific louvers and leave others open.
+        Alternatively, one can use the ``setLouvers`` command with value 0 in the
+        louver indices to close specific louvers and leave others open.
 
    * - Stop Dome and Engage Brakes
      - ``run_command.py``
@@ -1030,14 +1133,16 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
         * Louvers: ``0x8``
   
      - 
-       .. code-block:: python
-        :caption: run_command.py
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
+          :caption: run_command.py
 
-        component: MTDome
-        cmd: stop
-        parameters:
-          engageBrakes: true
-          subSystemIds: 0x1
+          component: MTDome
+          cmd: stop
+          parameters:
+            engageBrakes: true
+            subSystemIds: 0x1
 
    * - Recover from Dome Azimuth Fault
      - :file:`/recover_from_controller_fault.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/recover_from_controller_fault.py>`__]
@@ -1065,39 +1170,48 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
         * Dome Shutter: ``0x4``
         * Louvers: ``0x8``
 
-     - Most common subsystem fault is the Dome Azimuth Drives:
+     - 
+       .. dropdown:: run_command.py
+        
+        Most common subsystem fault is the Dome Azimuth Drives:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: MTDome
-        cmd: exitFault
-        parameters:
-          subSystemIds: 0x1
+         component: MTDome
+         cmd: exitFault
+         parameters:
+           subSystemIds: 0x1
 
    * - Reset Dome Azimuth Drives
      - ``run_command.py``
-     - To reset all dome azimuth drives:
+     - 
+       .. dropdown:: run_command.py
+        
+        To reset all dome azimuth drives:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: MTDome
-        cmd: resetDrivesAz
-        parameters:
-          reset: [1,1,1,1,1]
+         component: MTDome
+         cmd: resetDrivesAz
+         parameters:
+           reset: [1,1,1,1,1]
 
    * - Reset Dome Shutter Drives
      - ``run_command.py``
-     - To reset all dome shutter drives:
+     - 
+       .. dropdown:: run_command.py
+        
+        To reset all dome shutter drives:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: MTDome
-        cmd: resetDrivesShutter
-        parameters:
-          reset: [1,1,1,1]
+         component: MTDome
+         cmd: resetDrivesShutter
+         parameters:
+           reset: [1,1,1,1]
 
    * - Home Dome Azimuth
      - :file:`/home_dome.py`
@@ -1107,34 +1221,40 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
         | Required: ``physical_az`` (azimuth position as read by markings inside the dome).
         | See `Homing MTDome Procedure <https://rubinobs.atlassian.net/wiki/spaces/OOD/pages/705003522>`__.
 
-     - If the dome is parked, and its physical azimuth reads **310 deg**, instead of its true home position (328 deg):
+     - 
+       .. dropdown:: SAL Script
+        
+        If the dome is parked, and its physical azimuth reads **310 deg**, instead of its true home position (328 deg):
 
-       .. code-block:: python
-        :caption: home_dome.py
+        .. code-block:: python
+         :caption: home_dome.py
 
-        physical_az: 310
-        ignore:
-            - mtm1m3
-            - mtm2
-            - mtaos
-            - mtdometrajectory
-            - mthexapod_1
-            - mthexapod_2
-            - mtmount
-            - mtptg
-            - mtrotator
+         physical_az: 310
+         ignore:
+             - mtm1m3
+             - mtm2
+             - mtaos
+             - mtdometrajectory
+             - mthexapod_1
+             - mthexapod_2
+             - mtmount
+             - mtptg
+             - mtrotator
 
    * - Home Dome Shutter
      - ``run_command.py``
-     - Remember to include the ``subSystemIds`` parameter:
+     - 
+       .. dropdown:: run_command.py
+        
+        Remember to include the ``subSystemIds`` parameter:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: MTDome
-        cmd: home
-        parameters:
-          subSystemIds: 0x4
+         component: MTDome
+         cmd: home
+         parameters:
+           subSystemIds: 0x4
 
    * - Set Dome Shutter to Degraded Mode
      - ``run_command.py``
@@ -1146,16 +1266,19 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
         * ``1``: Normal Mode
         * ``2``: Degraded Mode (10% Performance)
 
-     - Remember to include the ``subSystemIds`` parameter:
+     - 
+       .. dropdown:: run_command.py
+        
+        Remember to include the ``subSystemIds`` parameter:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: MTDome
-        cmd: setOperationalMode
-        parameters:
-          operationalMode: 2
-          subSystemIds: 0x4
+         component: MTDome
+         cmd: setOperationalMode
+         parameters:
+           operationalMode: 2
+           subSystemIds: 0x4
 
    * - Rotate Dome at Constant Velocity
      - :file:`/crawl_az.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/crawl_az.py>`__]
@@ -1173,13 +1296,16 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
         
           direction: ClockWise
 
-     - If we want to move the dome counter-clockwise at a rate of 0.5 deg/second:
+     - 
+       .. dropdown:: SAL Script
+        
+        If we want to move the dome counter-clockwise at a rate of 0.5 deg/second:
 
-       .. code-block:: python
-        :caption: crawl_az.py
+        .. code-block:: python
+         :caption: crawl_az.py
 
-        direction: CounterClockWise
-        velocity: 0.5
+         direction: CounterClockWise
+         velocity: 0.5
 
 
 .. _Simonyi-SAL-Scripts-LSSTCam:
@@ -1238,26 +1364,29 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
         
         Units for ``focus_window`` and ``focus_step_sequence`` are in **microns**.
 
-     - | Required for defined focus window — use ``axis``, ``focus_window`` and ``n_steps``:
+     - 
+       .. dropdown:: SAL Script
+        
+        | Required for defined focus window — use ``axis``, ``focus_window`` and ``n_steps``:
 
-       .. code-block:: python
-          :caption: focus_sweep_lsstcam.py
+        .. code-block:: python
+           :caption: focus_sweep_lsstcam.py
 
-          axis: z
-          focus_window: 300
-          n_steps: 9
-          program: "BLOCK-T92"
-          hexapod: "Camera"
-          reason: "focus_sweep_cam_dz"
+           axis: z
+           focus_window: 300
+           n_steps: 9
+           program: "BLOCK-T92"
+           hexapod: "Camera"
+           reason: "focus_sweep_cam_dz"
 
-       | Or required for chosen steps — use ``axis`` and ``focus_step_sequence``:
+        | Or required for chosen steps — use ``axis`` and ``focus_step_sequence``:
 
-       .. code-block:: python
+        .. code-block:: python
 
-          axis: "y"
-          focus_step_sequence: [200, 50, -50, 200]
-          hexapod: "M2"
-          reason: "Sweep in y"
+           axis: "y"
+           focus_step_sequence: [200, 50, -50, 200]
+           hexapod: "M2"
+           reason: "Sweep in y"
 
    * - Change Filter
      - :file:`change_filter_lsstcam.py`
@@ -1266,13 +1395,16 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
         MTMount and MTRotator CSCs must be ``ENABLED`` for the script to run.
        
-     - The ``filter`` parameter is required for this script. 
-       To change to the ``z_20`` filter:
+     - 
+       .. dropdown:: SAL Script
+        
+        The ``filter`` parameter is required for this script. 
+        To change to the ``z_20`` filter:
 
-       .. code-block:: python
-          :caption: change_filter_lsstcam.py
+        .. code-block:: python
+           :caption: change_filter_lsstcam.py
 
-          filter: z_20
+           filter: z_20
 
    * - Take Image
      - :file:`take_image_lsstcam.py`
@@ -1295,55 +1427,61 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
         
         *Required Parameters:* ``exp_times`` and ``image_type``.
 
-     - Take a single five-second bias image:
-
-       .. code-block:: python
+     - 
+       .. dropdown:: SAL Script
         
-        :caption: take_image_lsstcam.py
+        Take a single five-second bias image:
 
-        image_type: BIAS
-        exp_times: 5
+        .. code-block:: python
+        
+         :caption: take_image_lsstcam.py
 
-       Take two five-second flat images (with a reason):
+         image_type: BIAS
+         exp_times: 5
 
-       .. code-block:: python
+        Take two five-second flat images (with a reason):
 
-        image_type: FLAT
-        exp_times: 5
-        nimages: 2
-        reason: "flat_test"
+        .. code-block:: python
 
-       Take a single one-second acquisition image for a test case:
+         image_type: FLAT
+         exp_times: 5
+         nimages: 2
+         reason: "flat_test"
 
-       .. code-block:: python
+        Take a single one-second acquisition image for a test case:
 
-        image_type: ACQ
-        exp_times: 1
-        program: "BLOCK-TXXXX"
+        .. code-block:: python
 
-       Take a single 30-second engineering test image:
+         image_type: ACQ
+         exp_times: 1
+         program: "BLOCK-TXXXX"
 
-       .. code-block:: python
+        Take a single 30-second engineering test image:
 
-        image_type: ENGTEST
-        exp_times: 30
-        nimages: 1
+        .. code-block:: python
+
+         image_type: ENGTEST
+         exp_times: 30
+         nimages: 1
 
    * - Track Target and Take Image
      - :file:`track_target_and_take_image_lsstcam.py`
-     - | All of the following parameters are required:
+     - 
+       .. dropdown:: SAL Script 
+        
+        | All of the following parameters are required:
 
-       .. code-block:: python
-          :caption: track_target_and_take_image_lsstcam.py
+        .. code-block:: python
+           :caption: track_target_and_take_image_lsstcam.py
 
-          ra: # ICRS right ascension (hour) in decimal hours or sexagesimal strings.
-          dec: # ICRS declination (deg) in decimal hours or sexagesimal strings.
-          rot_sky: # The position angle (deg) in the sky.
-          name: # Target name.
-          obs_time: # Time given for starting the slew
-          num_exp: # Number of exposures.
-          exp_times: # Array of exposure times in seconds.
-          band_filter: # Filter used for observation.
+           ra: # ICRS right ascension (hour) in decimal hours or sexagesimal strings.
+           dec: # ICRS declination (deg) in decimal hours or sexagesimal strings.
+           rot_sky: # The position angle (deg) in the sky.
+           name: # Target name.
+           obs_time: # Time given for starting the slew
+           num_exp: # Number of exposures.
+           exp_times: # Array of exposure times in seconds.
+           band_filter: # Filter used for observation.
 
    * - Take Stuttered Sequence
      - :file:`take_stuttered_lsstcam.py`
@@ -1366,17 +1504,20 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
 
         Units for ``dz`` are in **microns**.
 
-     - One can always add a ``reason`` to the triplet sequence.
+     - 
+       .. dropdown:: SAL Script
+        
+        One can always add a ``reason`` to the triplet sequence.
      
-       .. code-block:: python
-        :caption: take_aos_sequence_lsstcam.py
+        .. code-block:: python
+         :caption: take_aos_sequence_lsstcam.py
 
-        filter: z_20
-        exposure_time: 10
-        dz: 800
-        mode: TRIPLET
-        program: AOSSEQUENCE
-        reason: "test"
+         filter: z_20
+         exposure_time: 10
+         dz: 800
+         mode: TRIPLET
+         program: AOSSEQUENCE
+         reason: "test"
 
 
 .. _Simonyi-SAL-Scripts-LaserTracker:
@@ -1410,15 +1551,18 @@ LaserTracker
           # Target Options (REQUIRED): 
           # "M2", "Camera", or "CALIBRATION_SCREEN"
         
-     - To align to the calibration screen with a 0.01 deg angular tolerance:
+     - 
+       .. dropdown:: SAL Script
+        
+        To align to the calibration screen with a 0.01 deg angular tolerance:
        
-       .. code-block:: python
-        :caption: laser_tracker/align.py
+        .. code-block:: python
+         :caption: laser_tracker/align.py
 
-        target: CALIBRATION_SCREEN
-        tolerance_angular: 0.01
-        reason: "Align TMA to Calibration Screen"
-        program: "BLOCK-T495"
+         target: CALIBRATION_SCREEN
+         tolerance_angular: 0.01
+         reason: "Align TMA to Calibration Screen"
+         program: "BLOCK-T495"
 
        
    * - Park the LaserTracker
@@ -1429,17 +1573,20 @@ LaserTracker
         The LaserTracker parking command is now done by
         using ``id: BLOCK-T495`` in the :ref:`scheduler/add_block.py <Simonyi-SAL-Scripts-Scheduler>` script.
 
-     - To park the lasertracker at the p2 point on M1M3:
+     - 
+       .. dropdown:: run_command.py
+        
+        To park the lasertracker at the p2 point on M1M3:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: LaserTracker:1
-        cmd: measurePoint
-        parameters:
-          collection: A
-          pointgroup: M1M3
-          target: p2
+         component: LaserTracker:1
+         cmd: measurePoint
+         parameters:
+           collection: A
+           pointgroup: M1M3
+           target: p2
 
 
 
@@ -1459,15 +1606,18 @@ MTCalSys
    * - General
      - Open/close MTReflector
      - ``run_command.py``
-     - To open MTReflector
+     - 
+       .. dropdown:: run_command.py
+        
+        To open MTReflector
        
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: MTReflector
-        cmd: open
+         component: MTReflector
+         cmd: open
 
-       To close the reflector, use ``cmd: close``.
+        To close the reflector, use ``cmd: close``.
 
    * -
      - Park the Calibration Projector
@@ -1488,16 +1638,19 @@ MTCalSys
                    'CBP','Electrometer:101','Electrometer:102',
                    'FiberSpectrograph:101', 'FiberSpectrograph:102']
 
-     - We can change the ``sequence_name`` and ``ignore`` unnecessary CSCs 
-       based on the provided test cases on Zephyr Scale.
+     - 
+       .. dropdown:: SAL Script
+        
+        We can change the ``sequence_name`` and ``ignore`` unnecessary CSCs 
+        based on the provided test cases on Zephyr Scale.
 
-       .. code-block:: python
-        :caption: setup_whitelight_flats.py
+        .. code-block:: python
+         :caption: setup_whitelight_flats.py
 
-        sequence_name: 'laser_functional'
-        ignore: ['LinearStage:104', 'CBP',
-                 'Electrometer:102','Electrometer:101',
-                 'FiberSpectrograph:101','FiberSpectrograph:102']
+         sequence_name: 'laser_functional'
+         ignore: ['LinearStage:104', 'CBP',
+                  'Electrometer:102','Electrometer:101',
+                  'FiberSpectrograph:101','FiberSpectrograph:102']
 
    * -
      - Take Specified Whitelight Flats
@@ -1508,15 +1661,18 @@ MTCalSys
         | Default ``sequence_names: ["daily"]`` will run for all installed filters available (g, r, i, z, and u/y).
         | Metadata parameters available: ``note``, ``reason``, and ``program``.
 
-     - The following is an example of a specific type Photon Transfer Curve (PTC) script used, 
-       where the data is collected for the test case **BLOCK-T572**:
+     - 
+       .. dropdown:: SAL Script
+        
+        The following is an example of a specific type Photon Transfer Curve (PTC) script used, 
+        where the data is collected for the test case **BLOCK-T572**:
 
-       .. code-block:: python
-        :caption: take_whitelight_flats_lsstcam.py
+        .. code-block:: python
+         :caption: take_whitelight_flats_lsstcam.py
 
-        sequence_names: ['low_level_ptc']
-        reason: "low_level_led_ptc"
-        program: "BLOCK-T572"
+         sequence_names: ['low_level_ptc']
+         reason: "low_level_led_ptc"
+         program: "BLOCK-T572"
 
    * - CBP
      - Move the CBP to (Az, El) Position
@@ -1530,16 +1686,19 @@ MTCalSys
         | Az: [-45.0 to 45.0 deg]
         | El: [-69.0 to 45.0 deg]
 
-     - If we want to move the CBP to *Az = -0.05 deg* and *El = -46.5 deg*:
+     - 
+       .. dropdown:: run_command.py
+        
+        If we want to move the CBP to *Az = -0.05 deg* and *El = -46.5 deg*:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: CBP
-          cmd: move
-          parameters:
-            azimuth: -0.05
-            elevation: -46.5
+           component: CBP
+           cmd: move
+           parameters:
+             azimuth: -0.05
+             elevation: -46.5
 
    * -
      - Change the CBP Mask
@@ -1557,15 +1716,18 @@ MTCalSys
         
         Selection of the mask type for a test case is determined typically by calibration team.
 
-     - If we want to change the current CBP mask to *mask position 1*:
+     - 
+       .. dropdown:: run_command.py
+        
+        If we want to change the current CBP mask to *mask position 1*:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: CBP
-          cmd: changeMask
-          parameters:
-            mask: '1'
+           component: CBP
+           cmd: changeMask
+           parameters:
+             mask: '1'
 
    * -
      - Rotate the CBP Mask
@@ -1575,15 +1737,18 @@ MTCalSys
         
         Rotation is between 1 deg and 360 deg.
 
-     - If we want to rotate the CBP mask to 96.5 deg:
+     - 
+       .. dropdown:: run_command.py
+        
+        If we want to rotate the CBP mask to 96.5 deg:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: CBP
-        cmd: changeMaskRotation
-        parameters:
-          mask_rotation: 96.5
+         component: CBP
+         cmd: changeMaskRotation
+         parameters:
+           mask_rotation: 96.5
 
    * -
      - Set CBP Focus
@@ -1593,15 +1758,18 @@ MTCalSys
 
         Focus is measured in microns, and its range is [0, 13000] microns.
 
-     - If we want to set the focus to *3800 microns*:
+     - 
+       .. dropdown:: run_command.py
+        
+        If we want to set the focus to *3800 microns*:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: CBP
-          cmd: setFocus
-          parameters:
-            focus: 3800
+           component: CBP
+           cmd: setFocus
+           parameters:
+             focus: 3800
 
    * -
      - Park CBP
@@ -1612,7 +1780,9 @@ MTCalSys
         The CBP moves to elevation -70 deg, and it locks its motors when parking.
 
      - 
-       .. code-block:: python
+       .. dropdown:: run_command.py
+        
+        .. code-block:: python
           :caption: run_command.py
 
           component: CBP
@@ -1627,15 +1797,18 @@ MTCalSys
         Laser wavelengths are measured in nanometers (nm), and the range is between 
         350 - 1100nm during normal operations.
 
-     - To change the laser wavelength to *750nm*:
+     - 
+       .. dropdown:: run_command.py
+        
+        To change the laser wavelength to *750nm*:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: TunableLaser
-          cmd: changeWavelength
-          parameters:
-            wavelength: 750
+           component: TunableLaser
+           cmd: changeWavelength
+           parameters:
+             wavelength: 750
 
    * -
      - Set Laser Output Configuration
@@ -1645,14 +1818,17 @@ MTCalSys
         
         Available optical configurations are located in the `XML documentation <https://ts-xml.lsst.io/sal_interfaces/TunableLaser.html#enumerations>`__.
 
-     - To set the configuration to *F2 SCU*:
+     - 
+       .. dropdown:: run_command.py
+        
+        To set the configuration to *F2 SCU*:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          cmd: setOpticalConfiguration
-          parameters:
-            configuration: F2 SCU
+           cmd: setOpticalConfiguration
+           parameters:
+             configuration: F2 SCU
 
    * -
      - Change Tunable Laser Mode
@@ -1663,13 +1839,16 @@ MTCalSys
         There are two available laser modes: *Burst Mode* (``setBurstMode``) 
         and *Continuous Mode* (``setContinuousMode``).
 
-     - To set the tunable laser to *burst mode*:
+     - 
+       .. dropdown:: run_command.py
+        
+        To set the tunable laser to *burst mode*:
 
-       .. code-block:: python
-          :caption: run_command.py
+        .. code-block:: python
+           :caption: run_command.py
 
-          component: TunableLaser
-          cmd: setBurstMode
+           component: TunableLaser
+           cmd: setBurstMode
 
    * -
      - Start/Stop Tunable Laser Propagation
@@ -1679,15 +1858,18 @@ MTCalSys
         It is required to set the laser mode (burst/continous) *first* before 
         activating the laser propagation.
 
-     - To start propagation:
+     - 
+       .. dropdown:: run_command.py
+        
+        To start propagation:
 
-       .. code-block:: python
-        :caption: run_command.py
+        .. code-block:: python
+         :caption: run_command.py
 
-        component: TunableLaser
-        cmd: startPropagateLaser
+         component: TunableLaser
+         cmd: startPropagateLaser
 
-       To stop propagation, set ``cmd: stopPropagateLaser``.
+        To stop propagation, set ``cmd: stopPropagateLaser``.
 
 This procedure was last modified on |today|.
 

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -1,0 +1,1399 @@
+.. |author| replace:: *Kristopher Mortensen*
+.. |contributors| replace:: *OS Team*
+
+.. _Simonyi-SAL-Scripts-Configuration:
+
+############################################
+Simonyi SAL Scripts & Configurations
+############################################
+
+The following tables display the common SAL scripts used during operations with
+the Simonyi Telescope. These scripts are compatible with the LOVE MTQueue
+interface and include lower-level commands using ``run_command.py``.
+
+Scripts are available in the
+`ts_maintel_standardscripts <https://github.com/lsst-ts/ts_maintel_standardscripts/tree/develop/python/lsst/ts/maintel/standardscripts>`__
+repository, with common and useful configurations.
+Refer to `ts-xml <https://ts-xml.lsst.io>`__ to see the XML schema.
+
+The tables contain the following information:
+
+- A simple description of the action/command that the script initiates to the
+  appropriate CSCs.
+- The script name to search for in the ScriptQueue as well as a link to its
+  GitHub documentation.
+- Examples of common SAL script and/or ``run_command.py`` configurations.
+  Scripts that require empty configurations are labeled as "No configuration."
+
+
+.. _Simonyi-SAL-Scripts-MTM1M3:
+
+MTM1M3
+======
+
+Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m1m3`
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Raise M1M3 / Lower M1M3
+     - | :file:`/raise_m1m3.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/m1m3/raise_m1m3.py>`__)
+       | :file:`/lower_m1m3.py`
+     - No configuration
+   * - Slew Flags
+     - | :file:`/enable_m1m3_slew_controller_flags.py`
+       |
+       | Default config:
+       |
+       | ``slew_flags: [ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES, BOOSTERVALVES]``
+       | ``enable: [True, True, True, False]``
+     - | .. code-block:: text
+          :caption: enable_m1m3_slew_controller_flags.py
+
+          slew_flags: [ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES, BOOSTERVALVES]
+          enable: [True, True, True, False]
+
+       | Defaults as of May 2025:
+       | ``ACCELERATIONFORCES, BALANCEFORCES, VELOCITYFORCES: True``
+       | ``BOOSTERVALVES: False``
+   * - Enable Force Balance System / Disable Force Balance System
+     - | :file:`/enable_m1m3_balance_system.py`
+       | :file:`/disable_m1m3_balance_system.py`
+     - No configuration
+   * - Check M1M3 Individual hardpoint breakaway
+     - | :file:`/check_hardpoint.py`
+       |
+       | Default config:
+       |
+       | ``hardpoints: all``
+     - | To check specific hardpoints:
+
+       .. code-block:: text
+          :caption: check_hardpoint.py
+
+          hardpoints: [1, 2, 4]
+
+   * - Bump test on either a selection of individual actuators or on all actuators
+     - | :file:`/check_actuators.py`
+       |
+       | Default config:
+       |
+       | ``actuators: all``
+       | ``ignore_actuators: []``
+     - | Provide a list of the ``actuators`` to test:
+
+       .. code-block:: text
+          :caption: check_actuators.py
+
+          actuators: [101, 102, 103, 104]
+
+       | Or check ``all`` actuators and ``ignore_actuators``:
+
+       .. code-block:: text
+
+          actuators: all
+          ignore_actuators: [333, 412]
+
+   * - Enter engineering mode
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTM1M3
+          cmd: enterEngineering
+
+   * - Exit engineering mode
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTM1M3
+          cmd: exitEngineering
+
+
+.. _Simonyi-SAL-Scripts-MTM2:
+
+MTM2
+====
+
+Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m2`
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Enable/disable M2 closed-loop
+     - | :file:`/enable_m2_closed_loop.py`
+       | :file:`/m2/disable_m2_closed_loop.py`
+     - No configuration
+   * - Perform a M2 bump test on either a selection of individual actuators or on all axial actuators
+     - | :file:`/check_actuators.py`
+       |
+       | Default config:
+       |
+       | ``actuators: all``
+       | ``ignore_actuators: []``
+       | ``period: 60``
+       | ``force: 10``
+     - | Write specific actuators in an array to bump test only those:
+
+       .. code-block:: text
+          :caption: check_actuators.py
+
+          actuators: [121, 160]
+          period: 5
+          force: 10
+
+       | Or ignore certain actuators:
+
+       .. code-block:: text
+
+          ignore_actuators: [333, 412]
+
+
+.. _Simonyi-SAL-Scripts-MTHexapods:
+
+MTHexapods
+==========
+
+Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Turning on compensation mode
+     - | :file:`enable_hexapod_compensation_mode.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_hexapod_compensation_mode.py>`__)
+       | :file:`disable_hexapod_compensation_mode.py`
+       |
+       | Default config applies to both hexapods:
+       |
+       | ``components: ["M2Hexapod", "CameraHexapod"]``
+     - | For M2 Hexapod only:
+
+       .. code-block:: text
+          :caption: enable_hexapod_compensation_mode.py
+
+          components:
+            - M2Hexapod
+
+       | For Camera Hexapod only:
+
+       .. code-block:: text
+
+          components:
+            - CameraHexapod
+
+   * - Resetting M2 Hexapod (MTHexapod:2) or Camera Hexapod (MTHexapod:1) to a zero position
+     - | ``run_command.py``
+       |
+       | For Camera Hexapod use ``component: MTHexapod:1``
+       | For M2 Hexapod use ``component: MTHexapod:2``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTHexapod:2
+          cmd: move
+          parameters:
+            x: 0
+            y: 0
+            z: 0
+            u: 0
+            v: 0
+            w: 0
+
+       | **x, y, z** position in **microns** and **u, v, w** rotation in **degrees**.
+
+   * - Offset Camera Hexapod / Offset M2 Hexapod
+     - | :file:`offset_camera_hexapod.py`
+       | :file:`offset_m2_hexapod.py`
+       |
+       | Same schema for both SAL scripts.
+       | Properties:
+       |
+       | ``x:``
+       | ``y:``
+       | ``z:``
+       | ``u:``
+       | ``v:``
+       | ``reset_axes: false``
+       |
+       | **x, y, z** position in **microns** and **u, v** rotation in **degrees**.
+     - | Reset the positions before applying offsets in x, z and u axes:
+
+       .. code-block:: text
+          :caption: offset_camera_hexapod.py
+
+          x: 1
+          z: 3
+          u: 0.23
+          reset_axes: true
+
+       | To reset offsets from all axes:
+
+       .. code-block:: text
+
+          reset_axes: "all"
+
+       | Or to reset only certain axes:
+
+       .. code-block:: text
+
+          reset_axes: ["x", "z", "u"]
+
+   * - Enable Hexapods with new Configuration
+     - ``set_summary_state.py``
+     - | .. code-block:: text
+          :caption: set_summary_state.py
+
+          data:
+            -
+              - MTHexapod:1
+              - Standby
+            -
+              - MTHexapod:1
+              - Enabled
+              - laser_rotation_elevation_v18.yaml
+            -
+              - MTHexapod:2
+              - Standby
+            -
+              - MTHexapod:2
+              - Enabled
+              - laser_rotation_elevation_v18.yaml
+
+
+.. _Simonyi-SAL-Scripts-MTRotator:
+
+MTRotator
+=========
+
+Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/mtrotator`
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Move rotator to specific angle
+     - | :file:`/move_rotator.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtrotator/move_rotator.py>`__)
+       |
+       | ``angle`` range [-89, +89]
+     - | .. code-block:: text
+          :caption: move_rotator.py
+
+          angle: -45
+
+   * - Stop rotator
+     - :file:`stop_rotator.py`
+     - No configuration
+
+
+.. _Simonyi-SAL-Scripts-MTMount:
+
+MTMount
+=======
+
+| Path 1 (p1): :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
+| Path 2 (p2): :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/mtmount`
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Home TMA axes
+     - | :file:`{p1}/home_both_axes.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/home_both_axes.py>`__)
+       |
+       | Requires MTDome to be ``ENABLED`` or ``DISABLED``.
+       | Enables **M1M3 force balance system** and M2Hex and Cam Hex **compensation mode**.
+       | Offers the option to move to another position and home again.
+     - | .. code-block:: text
+          :caption: home_both_axes.py
+
+          final_home_position:
+            az: 1
+            el: 46
+
+       | The position (Az:1, El 46) was chosen to be run every time we home the axes,
+       | to avoid offsets inconsistency when homing at different positions.
+
+   * - Move TMA point to point
+     - | :file:`{p1}/move_p2p.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/move_p2p.py>`__)
+       |
+       | Default config:
+       | ``pause_for: 0``
+       | ``move_timeout: 120.0``
+       |
+       | If slewing to more than one target, use an array and the ``pause_for`` function.
+     - | Az [deg] / El [deg]:
+
+       .. code-block:: text
+          :caption: move_p2p.py
+
+          az: 70
+          el: 70
+
+       | Example for arrays:
+
+       .. code-block:: text
+
+          az: [70, 90, 110]
+          el: [70, 70, 70]
+
+       | Or RA [hrs] / Dec [deg]:
+
+       .. code-block:: text
+
+          ra: 4.59867
+          dec: 16.5092
+
+       | Array (sexagesimal as strings):
+
+       .. code-block:: text
+
+          ra: [4.59867, 20.2, "12:20:56.5"]
+          dec: [16.5092, 10.1, "-13:34:04.5"]
+
+   * - Point AzEl
+     - | :file:`{p1}/point_azel.py`
+       | (`base code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_point_azel.py>`__)
+       |
+       | Default config:
+       | ``rot_tel: 0.0``
+       | ``target_name: "AzEl"``
+       | ``wait_dome: false``
+       | ``slew_timeout: 240.0``
+     - | .. code-block:: text
+          :caption: point_azel.py
+
+          az: 80
+          el: 80
+
+   * - Track a target
+     - | :file:`{p1}/track_target.py`
+       | (`base code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_track_target.py>`__)
+       |
+       | Default config:
+       | ``offset: {x: 0, y: 0}``
+       | ``differential_tracking: {dra: 0.0, ddec: 0.0}``
+       | ``rot_type: "SkyAuto"``
+       | ``rot_value: 0``
+       | ``track_for: 0``
+       | ``stop_when_done: false``
+       | ``az_wrap_strategy: "OPTIMIZE"``
+       | ``slew_timeout: 240``
+       |
+       | `rot_type options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L230>`__
+       | `az_wrap_strategy options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L270>`__
+     - | Slew and track ICRS RaDec coordinates.
+       | RA in hours (0, 24), DEC in degrees (-90, +90):
+
+       .. code-block:: text
+          :caption: track_target.py
+
+          slew_icrs:
+            ra: 20.2
+            dec: 10.1
+
+       | RA, DEC in sexagesimal (as strings):
+
+       .. code-block:: text
+
+          slew_icrs:
+            ra: "12:20:56.5"
+            dec: "-13:34:04.5"
+
+       | Slew to AzEl and start tracking:
+
+       .. code-block:: text
+
+          track_azel:
+            az: 65
+            el: 45
+
+       | Slew and track a target name:
+
+       .. code-block:: text
+
+          target_name: HD150798
+
+       | Find a target based on AzEl and magnitude limit:
+
+       .. code-block:: text
+
+          find_target:
+            az: 65
+            el: 25
+            mag_limit: 8
+
+   * - Stop telescope tracking
+     - | :file:`{p1}/stop_tracking.py`
+       | (`base code <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_stop_tracking.py>`__)
+     - No configuration
+   * - Mirror cover operations
+     - | :file:`{p1}/close_mirror_covers.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/close_mirror_covers.py>`__)
+       | :file:`{p1}/open_mirror_covers.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/open_mirror_covers.py>`__)
+       |
+       | If El < 20°, script moves TMA to El 20°.
+       | Close (deploy) OR open (retract) the mirror covers.
+       | Lock M1M3 mirror covers.
+     - No configuration
+   * - Change the performance setting for the TMA
+     - | ``run_command.py``
+       |
+       | Remember to restore to default, as the settings are cumulative.
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          cmd: applySettingsSet
+          component: MTMount
+          parameters:
+            restoreDefaults: true
+            settings: 10percentperformance
+
+   * - Restore to TMA default settings
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          cmd: restoreDefaultSettings
+          component: MTMount
+
+   * - Unpark mount
+     - :file:`{p2}/unpark_mount.py`
+     - No configuration
+   * - Park mount
+     - :file:`{p2}/park_mount.py`
+     - In testing. DO NOT use (2026-6-16).
+
+
+.. _Simonyi-SAL-Scripts-MTAOS:
+
+MTAOS
+=====
+
+Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Issue correction
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTAOS
+          cmd: issueCorrection
+
+   * - Reset correction
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTAOS
+          cmd: resetCorrection
+
+   * - Reset Offset DOF
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTAOS
+          cmd: resetOffsetDOF
+
+   * - Enable/Disable AOS closed-loop
+     - | :file:`enable_aos_closed_loop.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_aos_closed_loop.py>`__)
+       | :file:`disable_aos_closed_loop.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/disable_aos_closed_loop.py>`__)
+     - | .. code-block:: text
+          :caption: enable_aos_closed_loop.py
+
+          used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+          truncation_index: [2]
+          zn_selected: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 20, 21, 22, 27, 28]
+
+   * - Set the absolute state of the telescope DOFs
+     - | :file:`set_dof.py`
+       |
+       | No default configuration.
+       | To ignore a component:
+       |
+       | ``ignore:``
+       | ``- mtmount``
+       | ``- mthexapod_1``
+       | ``- mthexapod_2``
+       | ``- mtrotator``
+     - | Uses a **previous image**:
+
+       .. code-block:: text
+          :caption: set_dof.py
+
+          day: 20250630
+          seq: 457
+
+       | Apply **individual dofs** (microns or arcsec):
+
+       .. code-block:: text
+
+          # Example: M1M3 bending mode 16
+          M1M3_B16: 0.3
+
+          # Example: M2 hexapod offset in x
+          M2_dx: 5
+
+       | Apply **multiple dofs** (50-dimensional vector):
+       | [0-4]: M2 Rigid Body Motions
+       | [5-9]: Camera Rigid Body Motions
+       | [10-29]: M1M3 Bending Modes
+       | [30-49]: M2 Bending Modes
+
+       .. code-block:: text
+
+          dofs: [0.0, 1.0, 2.0, 3.0, 4.0,
+          5.0, 6.0, 7.0, 8.0, 9.0,
+          10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0,
+          20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
+          30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0,
+          40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0]
+
+   * - Apply a DOF to the main telescope (bending mode or hexapod offset)
+     - :file:`apply_dof.py`
+     - Same configurations as ``set_dof.py``.
+   * - Enable and run closed-loop system on the AOS for LSSTCam
+     - :file:`close_loop_lsstcam.py`
+     - | .. code-block:: text
+          :caption: close_loop_lsstcam.py
+
+          exposure_time: 15
+          max_iter: 5
+          mode: "FAM"
+          program: "BLOCK-T249"
+          note: "initial_focus_dzs_tilts_bending_modes"
+          used_dofs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, 28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 45, 46]
+          apply_corrections: true
+          use_ocps: true
+          filter: "r_03"
+
+   * - Adjust M2/Camera Hexapods to focus PSFs manually
+     - | :file:`offset_m2_hexapod.py`
+       | :file:`offset_camera_hexapod.py`
+     - | If the first image shows a donut rather than a PSF, adjust by hand.
+       | Change the camera hexapod z by Dz = [(donut diameter in pixels) * 12] microns.
+
+       .. code-block:: text
+          :caption: offset_camera_hexapod.py
+
+          z: -Dz
+
+       | If that makes things worse (bigger donuts):
+
+       .. code-block:: text
+
+          z: +2 x Dz
+
+   * - Take Triplet Sequence with LSSTCam
+     - | :file:`take_aos_sequence_lsstcam.py`
+       |
+       | Defaults:
+       | ``filter:``
+       | ``exposure_time: 30``
+       | ``dz: 1500``
+       | ``n_sequences: 1``
+       | ``mode: TRIPLET``
+       | ``program: AOSSEQUENCE``
+     - | .. code-block:: text
+          :caption: take_aos_sequence_lsstcam.py
+
+          filter: z_03
+          exposure_time: 10
+          dz: 800
+          mode: TRIPLET
+          program: AOSSEQUENCE
+          reason: "test"
+
+
+.. _Simonyi-SAL-Scripts-MTDome:
+
+MTDome
+======
+
+Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/mtdome`
+
+``subSystemId`` enumerations in `MTDome XML <https://ts-xml.lsst.io/sal_interfaces/MTDome.html#enumerations>`__:
+
+- Azimuth Motion Control System (AMCS) = ``0x1``
+- Aperture Shutter Control System (APSCS) = ``0x4``
+- Louvers (LCS) = ``0x8``
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Enable/Disable dome following mode
+     - | :file:`/enable_dome_following.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/enable_dome_following.py>`__)
+       | :file:`/disable_dome_following.py`
+     - No configuration
+   * - Offset MTDome in Az
+     - | :file:`/offset_dome.py`
+       |
+       | Units of ``az`` in degrees.
+     - | .. code-block:: text
+          :caption: offset_dome.py
+
+          offset: 10
+
+   * - Slew MTDome in Az
+     - | :file:`/slew_dome.py`
+       |
+       | Units of ``az`` in degrees.
+     - | .. code-block:: text
+          :caption: slew_dome.py
+
+          az: 70
+          ignore:
+            - mtmount
+            - mthexapod_1
+            - mthexapod_2
+
+   * - Park / Unpark MTDome
+     - | :file:`/park_dome.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/park_dome.py>`__)
+       | :file:`/unpark_dome.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/unpark_dome.py>`__)
+     - | .. code-block:: text
+          :caption: park_dome.py
+
+          ignore:
+            - mtm1m3
+            - mtm2
+            - mtaos
+            - mtdometrajectory
+            - mthexapod_1
+            - mthexapod_2
+
+   * - Open/Close MTDome
+     - | :file:`/open_dome.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/open_dome.py>`__)
+       | :file:`/close_dome.py`
+       |
+       | Both scripts have the ``force`` property, useful to bypass errors
+       | or conditions (e.g., dome telemetry reports shutters in wrong state,
+       | mirror covers lost instead of closed).
+     - | No configuration, but you can ignore certain CSCs:
+
+       .. code-block:: text
+          :caption: open_dome.py
+
+          force: false
+          ignore:
+            - mtm1m3
+            - mtm2
+            - mtaos
+            - mtdometrajectory
+            - mthexapod_1
+            - mthexapod_2
+            - mtmount
+            - mtptg
+            - mtrotator
+
+   * - Open/Close MTDome (via run_command)
+     - ``run_command.py``
+     - | To open:
+
+       .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: openShutter
+
+       | To close:
+
+       .. code-block:: text
+
+          component: MTDome
+          cmd: closeShutter
+
+   * - Open Dome Louvers
+     - | ``run_command.py``
+       |
+       | The array values are between 0.0 (**closed**) and 100.0 (fully **open**).
+       |
+       | Louver index (0-based):
+       | [A1, A2, **B1**, B2, B3, C1, C2, C3, D1, D2, D3, **E1**, **E2**, E3,
+       | F1, F2, F3, G1, G2, G3, **H1**, **H2**, H3, I1, I2, I3, L1, L2, L3,
+       | **M1**, M2, M3, N1, N2]
+       |
+       | Bold = louvers available as of 2026-2-14.
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: setLouvers
+          parameters:
+            position: [0.0, 0.0, 100.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 100.0, 100.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 0.0,
+          100.0, 100.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 100.0,
+          0.0, 0.0, 0.0, 0.0]
+
+   * - Close Dome Louvers
+     - | ``run_command.py``
+       |
+       | Alternatively use the ``setLouvers`` command with value 0 in the
+       | louver index you want to close.
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: closeLouvers
+
+   * - Stop dome and engage brakes
+     - | ``run_command.py``
+       |
+       | ``stop`` `command <https://ts-xml.lsst.io/sal_interfaces/MTDome.html#stop>`__
+       | DomeAz: ``subSystemIds: 0x1``
+       | Dome shutter: ``subSystemIds: 0x4``
+       | Louvers: ``subSystemIds: 0x8``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: stop
+          parameters:
+            engageBrakes: true
+            subSystemIds: 0x?
+
+   * - Recover from Dome Az FAULT
+     - | :file:`/recover_from_controller_fault.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/recover_from_controller_fault.py>`__)
+       |
+       | ``delta_move: 3.0``
+       |
+       | Clears a dome controller fault, moves the dome slightly to confirm
+       | it works again, and re-enables dome following if successful.
+     - No configuration required
+   * - Exit Fault/Clear fault in subsystem
+     - | ``run_command.py``
+       |
+       | DomeAz: ``subSystemIds: 0x1``
+       | Dome shutter: ``subSystemIds: 0x4``
+       | Louvers: ``subSystemIds: 0x8``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: exitFault
+          parameters:
+            subSystemIds: 0x?
+
+   * - Reset dome drives
+     - | ``run_command.py``
+       |
+       | (``exitFault`` will issue a ``resetDrivesAz`` internally; probably not needed)
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: resetDrivesAz
+          parameters:
+            reset: [1,1,1,1,1]
+
+   * - Reset Dome shutter drives
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: resetDrivesShutter
+          parameters:
+            reset: [1,1,1,1]
+
+   * - Home Dome Az
+     - | :file:`/home_dome.py`
+       |
+       | Required: ``physical_az`` (azimuth position as read by markings).
+       |
+       | See `Homing MTDome procedure <https://rubinobs.atlassian.net/wiki/spaces/OOD/pages/705003522>`__.
+     - | .. code-block:: text
+          :caption: home_dome.py
+
+          physical_az: <physical position as read by markings>
+          ignore:
+            - mtm1m3
+            - mtm2
+            - mtaos
+            - mtdometrajectory
+            - mthexapod_1
+            - mthexapod_2
+            - mtmount
+            - mtptg
+            - mtrotator
+
+   * - Home Dome shutter
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: home
+          parameters:
+            subSystemIds: 0x4
+
+   * - Set dome shutter to degraded mode
+     - | ``run_command.py``
+       |
+       | Dome operational modes:
+       | **1:** Normal mode
+       | **2:** Degraded mode
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTDome
+          cmd: setOperationalMode
+          parameters:
+            operationalMode: 2
+            subSystemIds: 0x4
+
+   * - Crawl - Move the azimuth axis at constant velocity
+     - | :file:`/crawl_az.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/crawl_az.py>`__)
+       |
+       | Includes ``position`` and ``velocity`` properties.
+       | Speed in deg/second.
+       |
+       | Default config:
+       | ``direction: ClockWise``
+     - | .. code-block:: text
+          :caption: crawl_az.py
+
+          direction: CounterClockWise
+          velocity: 0.5
+
+
+.. _Simonyi-SAL-Scripts-LSSTCam:
+
+LSSTCam
+=======
+
+Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/`
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Enable LSSTCam
+     - | :file:`enable_lsstcam.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/enable_lsstcam.py>`__)
+     - Not available
+   * - Put LSSTCam in STANDBY
+     -
+     - Not available
+   * - Focus Sweep
+     - | :file:`focus_sweep_lsstcam.py`
+       |
+       | Properties with default config:
+       | ``sim: false``
+       | ``hexapod: Camera``
+       | ``filter: null``
+       | ``exp_time: 10``
+       | ``axis: ["x", "y", "z", "u", "v"]``
+       | ``focus_window:``
+       | ``n_steps:``
+       | ``focus_step_sequence:``
+       | ``n_images_per_step: 1``
+       | ``program: FOCUS_SWEEP``
+       | ``reason: null``
+       | ``ignore:``
+       |
+       | Units are microns.
+     - | Required for defined focus window — use ``axis``, ``focus_window`` and ``n_steps``:
+
+       .. code-block:: text
+          :caption: focus_sweep_lsstcam.py
+
+          axis: z
+          focus_window: 300
+          n_steps: 9
+          program: "BLOCK-T92"
+          hexapod: "Camera"
+          reason: "focus_sweep_cam_dz"
+
+       | Or required for chosen steps — use ``axis`` and ``focus_step_sequence``:
+
+       .. code-block:: text
+
+          axis: "y"
+          focus_step_sequence: [200, 50, -50, 200]
+          hexapod: "M2"
+          reason: "Sweep in y"
+
+   * - Change Filter
+     - | :file:`change_filter_lsstcam.py`
+       |
+       | Required: ``filter``
+     - | .. code-block:: text
+          :caption: change_filter_lsstcam.py
+
+          filter: <filter_name>
+
+   * - Take Image
+     - | :file:`take_image_lsstcam.py`
+       |
+       | ``filter:``
+       | ``nimages: null``
+       | ``exp_times: 0``
+       | ``image_type: ["BIAS", "DARK", "FLAT", "OBJECT", "ENGTEST", "ACQ", "SPOT", "CWFS", "FOCUS"]``
+       | ``reason:``
+       | ``program:``
+       | ``note:``
+       |
+       | Required: ``image_type``
+     - | .. code-block:: text
+          :caption: take_image_lsstcam.py
+
+          image_type: BIAS
+
+       .. code-block:: text
+
+          image_type: FLAT
+          exp_times: 5
+          nimages: 2
+          reason: "flat_test"
+
+       .. code-block:: text
+
+          image_type: ACQ
+          exp_times: 1
+          program: "BLOCK-TXXXX"
+
+       .. code-block:: text
+
+          image_type: ENGTEST
+          exp_times: 30
+          nimages: 1
+
+   * - Track target and take image
+     - :file:`track_target_and_take_image_lsstcam.py`
+     - | All these are required:
+
+       .. code-block:: text
+          :caption: track_target_and_take_image_lsstcam.py
+
+          ra:
+          dec:
+          rot_sky:
+          name:
+          obs_time:
+          num_exp:
+          exp_times:
+          band_filter:
+
+   * - Take Stuttered
+     - :file:`take_stuttered_lsstcam.py`
+     - | Configuration in
+       | `take_stuttered_lsstcam.py source <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/take_stuttered_lsstcam.py>`__
+   * - Take Triplets
+     - | :file:`maintel/take_aos_sequence_lsstcam.py`
+       |
+       | ``filter:``
+       | ``exposure_time: 30``
+       | ``dz: 1500``
+       | ``n_sequences: 1``
+       | ``mode: TRIPLET``
+       | ``program: AOSSEQUENCE``
+     - | .. code-block:: text
+          :caption: take_aos_sequence_lsstcam.py
+
+          filter: z_03
+          exposure_time: 10
+          dz: 800
+          mode: TRIPLET
+          program: AOSSEQUENCE
+          reason: "test"
+
+
+.. _Simonyi-SAL-Scripts-LaserTracker:
+
+LaserTracker
+============
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Align the TMA to the calibration screen
+     - | :file:`laser_tracker/align.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/laser_tracker/align.py>`__)
+       |
+       | Default config:
+       | ``max_iter: 10``
+       | ``tolerance_linear: 0.0001`` (meters)
+       | ``tolerance_angular: 0.00138`` (deg, ~5 arcsec)
+       | ``target: M2`` (REQUIRED)
+       |
+       | ``target`` options: "M2", "Camera", "CALIBRATION_SCREEN"
+     - | .. code-block:: text
+          :caption: laser_tracker/align.py
+
+          target: CALIBRATION_SCREEN
+          tolerance_angular: 0.01
+          reason: "Align TMA to Calibration Screen"
+          program: "BLOCK-T495"
+
+       .. note::
+
+          The LaserTracker Measurement of the Calibration screen is done now
+          using ``id: BLOCK-T495``.
+
+   * - Park the lasertracker
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: LaserTracker:1
+          cmd: measurePoint
+          parameters:
+            collection: A
+            pointgroup: M1M3
+            target: p2
+
+
+.. _Simonyi-SAL-Scripts-MTCalSys:
+
+MTCalSys
+========
+
+.. list-table::
+   :widths: 10 20 35 35
+   :header-rows: 1
+
+   * - CSC
+     - Command
+     - SAL Script
+     - Script Configuration
+   * - MTReflector
+     - Open/close MTReflector
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: MTReflector
+          cmd: open
+
+       | (or ``cmd: close``)
+
+   * -
+     - Park the calibration projector
+     - :file:`maintel/park_calibration_projector.py`
+     - No configuration
+   * -
+     - Setup LEDProjector for White light flats
+     - | :file:`maintel/setup_whitelight_flats.py`
+       |
+       | Default config:
+       | ``sequence_name: "whitelight_u_source"``
+       | ``ignore: ['TunableLaser','LinearStage:104','FiberSpectrograph:101','FiberSpectrograph:102','CBP','Electrometer:102','Electrometer:101']``
+     - | .. code-block:: text
+          :caption: setup_whitelight_flats.py
+
+          sequence_name: 'laser_functional'
+          ignore: ['LinearStage:104','FiberSpectrograph:101','FiberSpectrograph:102','CBP','Electrometer:102','Electrometer:101']
+
+   * -
+     - Take whitelight flats for a given setup
+     - | :file:`maintel/take_whitelight_flats_lsstcam.py`
+       | (`code <https://github.com/lsst-ts/ts_externalscripts/blob/develop/python/lsst/ts/externalscripts/maintel/take_whitelight_flats_lsstcam.py>`__)
+       |
+       | Default will run for all installed filters:
+       | ``sequence_names: ["daily"]``
+       | Metadata: ``note``, ``reason``, ``program``
+     - | .. code-block:: text
+          :caption: take_whitelight_flats_lsstcam.py
+
+          sequence_names: ['low_level_ptc']
+          reason: "low_level_led_ptc"
+          program: "BLOCK-T572"
+
+   * - CBP
+     - Move the CBP Az, El position
+     - | ``run_command.py``
+       |
+       | ``azimuth`` and ``elevation`` are float in degrees.
+       | Az: [-45.0 to 45.0 deg]
+       | El: [-69.0 to 45.0 deg]
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: CBP
+          cmd: move
+          parameters:
+            azimuth: -0.05
+            elevation: -46.5
+
+   * -
+     - Change the CBP mask
+     - | ``run_command.py``
+       |
+       | There are 5 masks to characterize the beam projection.
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: CBP
+          cmd: changeMask
+          parameters:
+            mask: '1'
+
+   * -
+     - Rotate the CBP mask
+     - | ``run_command.py``
+       |
+       | Rotation is between 1 and 360 deg.
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: CBP
+          cmd: changeMaskRotation
+          parameters:
+            mask_rotation: 96.5
+
+   * -
+     - Set CBP focus
+     - | ``run_command.py``
+       |
+       | Focus in microns. Range is (0, 13000).
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: CBP
+          cmd: setFocus
+          parameters:
+            focus: 3800
+
+   * -
+     - Park CBP (moves to elevation -70, locks the motors)
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: CBP
+          cmd: park
+
+   * - Tunable Laser
+     - Set tunable laser wavelength
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: TunableLaser
+          cmd: changeWavelength
+          parameters:
+            wavelength: 750
+
+   * -
+     - Set laser output configuration
+     - | ``run_command.py``
+       |
+       | Configurations available: (see XML documentation)
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          cmd: setOpticalConfiguration
+          parameters:
+            configuration: F2 SCU
+
+   * -
+     - Change tunable laser mode
+     - | ``run_command.py``
+       |
+       | Available modes: ``setBurstMode`` and ``setContinuousMode``.
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: TunableLaser
+          cmd: setBurstMode
+
+   * -
+     - Start/stop tunable laser propagation
+     - | ``run_command.py``
+       |
+       | Start cmd: ``startPropagateLaser``
+       | Stop cmd: ``stopPropagateLaser``
+       |
+       | Note: requires setting the mode first.
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          component: TunableLaser
+          cmd: startPropagateLaser
+
+   * -
+     - Set laser output to F2 SCU
+     - ``run_command.py``
+     - | .. code-block:: text
+          :caption: run_command.py
+
+          cmd: setOpticalConfiguration
+          parameters:
+            configuration: F2 SCU
+
+
+.. _Simonyi-SAL-Scripts-Scheduler:
+
+Scheduler
+=========
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Enable Scheduler:1
+     - | :file:`maintel/scheduler/enable.py`
+       |
+       | Properties: ``config`` (string): Name of the configuration .yaml file.
+       | This loads the .yaml configuration file and can also be used to
+       | state-cycle the scheduler.
+     - | .. code-block:: text
+          :caption: maintel/scheduler/enable.py
+
+          config: <config_file_name>.yaml
+
+   * - Start scheduler-driven observations
+     - :file:`maintel/scheduler/resume.py`
+     - No configuration
+   * - Stop scheduler-driven observations
+     - :file:`maintel/scheduler/stop.py`
+     - No configuration
+   * - Start a testing BLOCK
+     - | :file:`maintel/scheduler/add_block.py`
+       |
+       | Properties:
+       | ``id`` (string): Name of the BLOCK to be run.
+       | ``override``: List of parameters to be changed/updated in the BLOCK.
+       |
+       | Current available BLOCKs listed
+       | `here <https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=10064>`__.
+     - | e.g. Measurement of Laser Tracker targets:
+
+       .. code-block:: text
+          :caption: maintel/scheduler/add_block.py
+
+          id: BLOCK-T89
+
+
+.. _Simonyi-SAL-Scripts-General:
+
+General Scripts
+===============
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Command
+     - SAL Script
+     - Script Configuration
+   * - Set Summary State to OFFLINE/ENABLED/DISABLED/STANDBY
+     - | ``set_summary_state.py``
+       |
+       | Subsystems accepted: ``MTMount``, ``MTRotator``, ``MTHexapod:1`` (Cam),
+       | ``MTHexapod:2`` (M2), ``MTM2``, ``MTPtg``, ``MTAOS``, ``MTDome``, ``MTM1M3``
+       |
+       | States accepted: ``STANDBY``, ``ENABLED``, ``DISABLED``, ``OFFLINE``
+     - | .. code-block:: text
+          :caption: set_summary_state.py
+
+          data:
+            - [MTMount, DISABLED]
+
+       | or:
+
+       .. code-block:: text
+
+          data:
+            -
+              - MTAOS
+              - STANDBY
+
+   * - self.group.components naming convention
+     - | The name of the CSC must match the name of the CSC in ``group.components``,
+       | which is the name of the CSC in lowercase, replacing the ":" with "_"
+       | for indexed components.
+     - | e.g. ``ATMCS`` → ``atmcs``
+       | ``MTHexapod:1`` → ``hexapod_1``
+       |
+       | To use an ``ignore`` property:
+
+       .. code-block:: text
+
+          ignore:
+            - mtdometrajectory
+            - hexapod_1
+            - mtaos
+
+   * - Checks and prepares key telescope systems
+     - | :file:`ensure_on_sky_readiness.py`
+       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/ensure_onsky_readiness.py>`__)
+     - | Default config:
+
+       .. code-block:: text
+          :caption: ensure_on_sky_readiness.py
+
+          slew_flags = ["ACCELERATIONFORCES", "BALANCEFORCES",
+            "VELOCITYFORCES", "BOOSTERVALVES"]
+          enable_flags = [True, True, True, False]
+
+   * - Enable EAS with different configuration
+     - ``set_summary_state.py``
+     - | .. code-block:: text
+          :caption: set_summary_state.py
+
+          data:
+            - [EAS, STANDBY]
+            - [EAS, ENABLED, "disable_m1m3ts.yaml"]
+
+
+This procedure was last modified on |today|.
+
+

--- a/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
+++ b/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.rst
@@ -23,7 +23,7 @@ The tables contain the following information:
 - The script name to search for in the ScriptQueue as well as a link to its
   GitHub documentation.
 - Examples of common SAL script and/or ``run_command.py`` configurations.
-  Scripts that require empty configurations are labeled as "No configuration."
+  Scripts that require empty configurations are labeled as "No Configuration.."
 
 
 .. _Simonyi-SAL-Scripts-MTM1M3:
@@ -43,7 +43,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Raise/Lower M1M3
      - | :file:`/raise_m1m3.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/m1m3/raise_m1m3.py>`__]
        | :file:`/lower_m1m3.py`
-     - No configuration
+     - No Configuration.
    * - Slew Flags
      - :file:`/enable_m1m3_slew_controller_flags.py`
      - Default Configuration:
@@ -59,7 +59,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Enable/Disable Force Balance System
      - | :file:`/enable_m1m3_balance_system.py`
        | :file:`/disable_m1m3_balance_system.py`
-     - No configuration
+     - No Configuration.
    * - Check M1M3 Hardpoint Breakaway
      - | :file:`/check_hardpoint.py`
        |
@@ -136,7 +136,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
    * - Enable/Disable M2 Closed-Loop
      - | :file:`/enable_m2_closed_loop.py`
        | :file:`/disable_m2_closed_loop.py`
-     - No configuration
+     - No Configuration.
    * - M2 Bump Test Any/All Actuators
      - | :file:`/check_actuators.py`
        |
@@ -302,7 +302,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
 
    * - Stop Rotator
      - :file:`stop_rotator.py`
-     - No configuration
+     - No Configuration.
 
 
 .. _Simonyi-SAL-Scripts-MTMount:
@@ -314,39 +314,42 @@ MTMount
 | Path 2 (p2): :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/mtmount`
 
 .. list-table::
-   :widths: 20 40 40
+   :widths: 20 50 30
    :header-rows: 1
 
    * - Command
      - SAL Script
      - Script Configuration
-   * - Home TMA axes
-     - | :file:`{p1}/home_both_axes.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/home_both_axes.py>`__)
+   * - Home TMA Axes
+     - :file:`{p1}/home_both_axes.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/home_both_axes.py>`__]
+       
+       | Requires MTDome CSC in ``ENABLED`` or ``DISABLED``.
        |
-       | Requires MTDome to be ``ENABLED`` or ``DISABLED``.
        | Enables **M1M3 force balance system** and M2Hex and Cam Hex **compensation mode**.
+       |
        | Offers the option to move to another position and home again.
-     - | .. code-block:: python
-          :caption: home_both_axes.py
+     - 
+       .. code-block:: python
+        :caption: home_both_axes.py
 
-          final_home_position:
-            az: 1
-            el: 46
+        final_home_position:
+          az: 1
+          el: 46
 
-       | The position (Az:1, El 46) was chosen to be run every time we home the axes,
-       | to avoid offsets inconsistency when homing at different positions.
+       The position (Az: 1, El: 46) was chosen to be run every time we home the axes, 
+       to avoid offsets inconsistency when homing at different positions.
 
-   * - Move TMA point to point
-     - | :file:`{p1}/move_p2p.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/move_p2p.py>`__)
+   * - Move TMA Point-to-Point
+     - | :file:`{p1}/move_p2p.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/move_p2p.py>`__]
        |
        | Default config:
-       | ``pause_for: 0``
-       | ``move_timeout: 120.0``
-       |
-       | If slewing to more than one target, use an array and the ``pause_for`` function.
-     - | Az [deg] / El [deg]:
+
+       .. code-block:: python
+        
+        pause_for: 0
+        move_timeout: 120.0
+       
+     - Select a single point in Az (deg), El (deg) or in RA (hrs), Dec (deg):
 
        .. code-block:: python
           :caption: move_p2p.py
@@ -354,59 +357,69 @@ MTMount
           az: 70
           el: 70
 
-       | Example for arrays:
-
-       .. code-block:: python
-
-          az: [70, 90, 110]
-          el: [70, 70, 70]
-
-       | Or RA [hrs] / Dec [deg]:
-
        .. code-block:: python
 
           ra: 4.59867
           dec: 16.5092
 
-       | Array (sexagesimal as strings):
+       If slewing to more than one target, use an array and the ``pause_for`` function.
+
+       .. code-block:: python
+
+          az: [70, 90, 110]
+          el: [70, 70, 70]
+          pause_for: 30
 
        .. code-block:: python
 
           ra: [4.59867, 20.2, "12:20:56.5"]
           dec: [16.5092, 10.1, "-13:34:04.5"]
+          pause_for: 15
 
-   * - Point AzEl
-     - | :file:`{p1}/point_azel.py`
-       | (`base code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_point_azel.py>`__)
-       |
-       | Default config:
-       | ``rot_tel: 0.0``
-       | ``target_name: "AzEl"``
-       | ``wait_dome: false``
-       | ``slew_timeout: 240.0``
-     - | .. code-block:: python
-          :caption: point_azel.py
+       .. note::
+        
+        For (RA, Dec) arrays, sexagesimals may be added as strings.
 
-          az: 80
-          el: 80
+   * - Point (Az, El)
+     - | :file:`{p1}/point_azel.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_point_azel.py>`__]
+       |
+       | Default Config:
 
-   * - Track a target
-     - | :file:`{p1}/track_target.py`
-       | (`base code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_track_target.py>`__)
-       |
-       | Default config:
-       | ``offset: {x: 0, y: 0}``
-       | ``differential_tracking: {dra: 0.0, ddec: 0.0}``
-       | ``rot_type: "SkyAuto"``
-       | ``rot_value: 0``
-       | ``track_for: 0``
-       | ``stop_when_done: false``
-       | ``az_wrap_strategy: "OPTIMIZE"``
-       | ``slew_timeout: 240``
-       |
-       | `rot_type options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L230>`__
-       | `az_wrap_strategy options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L270>`__
-     - | Slew and track ICRS RaDec coordinates.
+       .. code-block:: python
+        
+        rot_tel: 0.0
+        target_name: "AzEl"
+        wait_dome: false
+        slew_timeout: 240.0
+
+     - 
+       .. code-block:: python
+        :caption: point_azel.py
+
+        az: 80
+        el: 80
+
+   * - Track Target
+     - :file:`{p1}/track_target.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/develop/python/lsst/ts/standardscripts/base_track_target.py>`__]
+       
+       * `rot_type Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L230>`__
+       * `az_wrap_strategy Options <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_track_target.py#L270>`__
+
+       | Default Config:
+       
+       .. code-block:: python
+        
+        offset: {x: 0, y: 0}``
+        differential_tracking: {dra: 0.0, ddec: 0.0}``
+        rot_type: "SkyAuto"
+        rot_value: 0
+        track_for: 0
+        stop_when_done: false
+        az_wrap_strategy: "OPTIMIZE"
+        slew_timeout: 240
+       
+       
+     - | Slew and track ICRS RA, Dec coordinates.
        | RA in hours (0, 24), DEC in degrees (-90, +90):
 
        .. code-block:: python
@@ -416,7 +429,7 @@ MTMount
             ra: 20.2
             dec: 10.1
 
-       | RA, DEC in sexagesimal (as strings):
+       | RA, DEC in sexagesimals (as strings):
 
        .. code-block:: python
 
@@ -424,7 +437,7 @@ MTMount
             ra: "12:20:56.5"
             dec: "-13:34:04.5"
 
-       | Slew to AzEl and start tracking:
+       | Slew to Az, El and start tracking:
 
        .. code-block:: python
 
@@ -447,47 +460,55 @@ MTMount
             el: 25
             mag_limit: 8
 
-   * - Stop telescope tracking
-     - | :file:`{p1}/stop_tracking.py`
-       | (`base code <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_stop_tracking.py>`__)
-     - No configuration
-   * - Mirror cover operations
-     - | :file:`{p1}/close_mirror_covers.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/close_mirror_covers.py>`__)
-       | :file:`{p1}/open_mirror_covers.py`
-       | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/open_mirror_covers.py>`__)
-       |
-       | If El < 20°, script moves TMA to El 20°.
-       | Close (deploy) OR open (retract) the mirror covers.
-       | Lock M1M3 mirror covers.
-     - No configuration
-   * - Change the performance setting for the TMA
-     - | ``run_command.py``
-       |
-       | Remember to restore to default, as the settings are cumulative.
-     - | .. code-block:: python
-          :caption: run_command.py
+   * - Stop Telescope Tracking
+     - | :file:`{p1}/stop_tracking.py` [`code <https://github.com/lsst-ts/ts_standardscripts/blob/3e27256466ac0b4dc0c3b7fa66c88304225d301a/python/lsst/ts/standardscripts/base_stop_tracking.py>`__]
+     - No Configuration.
+   * - Open/Close Mirror Covers
+     - | :file:`{p1}/open_mirror_covers.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/open_mirror_covers.py>`__]
+       | :file:`{p1}/close_mirror_covers.py` [`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/close_mirror_covers.py>`__]
 
-          cmd: applySettingsSet
-          component: MTMount
-          parameters:
-            restoreDefaults: true
-            settings: 10percentperformance
-
-   * - Restore to TMA default settings
+       * If El < 20°, script moves TMA to El 20°.
+       * Closes (deploys) OR opens (retracts) the mirror covers.
+       * Lock M1M3 mirror covers.
+     - No Configuration.
+   * - Change TMA Performance Settings
      - ``run_command.py``
-     - | .. code-block:: python
-          :caption: run_command.py
+     
+       .. note:: 
+        
+        Remember to restore to default, as the settings are cumulative.
 
-          cmd: restoreDefaultSettings
-          component: MTMount
+     - 
+       .. code-block:: python
+        :caption: run_command.py
 
-   * - Unpark mount
+        cmd: applySettingsSet
+        component: MTMount
+        parameters:
+          restoreDefaults: true
+          settings: 10percentperformance
+
+   * - Restore TMA to Default Settings
+     - ``run_command.py``
+     - 
+       .. code-block:: python
+        :caption: run_command.py
+
+        component: MTMount
+        cmd: restoreDefaultSettings
+
+   * - Unpark Mount
      - :file:`{p2}/unpark_mount.py`
-     - No configuration
-   * - Park mount
+     - No Configuration.
+   * - Park Mount
      - :file:`{p2}/park_mount.py`
-     - In testing. DO NOT use (2026-6-16).
+
+       .. admonition:: DO NOT USE!
+        :class: warning
+
+        Currently in testing (2026-6-16).
+
+     - No Configuration.
 
 
 .. _Simonyi-SAL-Scripts-MTAOS:
@@ -664,7 +685,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
      - | :file:`/enable_dome_following.py`
        | (`code <https://github.com/lsst-ts/ts_maintel_standardscripts/blob/develop/python/lsst/ts/maintel/standardscripts/mtdome/enable_dome_following.py>`__)
        | :file:`/disable_dome_following.py`
-     - No configuration
+     - No Configuration.
    * - Offset MTDome in Az
      - | :file:`/offset_dome.py`
        |
@@ -711,7 +732,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        | Both scripts have the ``force`` property, useful to bypass errors
        | or conditions (e.g., dome telemetry reports shutters in wrong state,
        | mirror covers lost instead of closed).
-     - | No configuration, but you can ignore certain CSCs:
+     - | No Configuration., but you can ignore certain CSCs:
 
        .. code-block:: python
           :caption: open_dome.py
@@ -805,7 +826,7 @@ Path: :file:`ts_maintel_standardscripts/python/lsst/ts/maintel/standardscripts/m
        |
        | Clears a dome controller fault, moves the dome slightly to confirm
        | it works again, and re-enables dome following if successful.
-     - No configuration required
+     - No Configuration. required
    * - Exit Fault/Clear fault in subsystem
      - | ``run_command.py``
        |
@@ -1125,7 +1146,7 @@ MTCalSys
    * -
      - Park the calibration projector
      - :file:`maintel/park_calibration_projector.py`
-     - No configuration
+     - No Configuration.
    * -
      - Setup LEDProjector for White light flats
      - | :file:`maintel/setup_whitelight_flats.py`
@@ -1302,10 +1323,10 @@ Scheduler
 
    * - Start scheduler-driven observations
      - :file:`maintel/scheduler/resume.py`
-     - No configuration
+     - No Configuration.
    * - Stop scheduler-driven observations
      - :file:`maintel/scheduler/stop.py`
-     - No configuration
+     - No Configuration.
    * - Start a testing BLOCK
      - | :file:`maintel/scheduler/add_block.py`
        |

--- a/Simonyi/index.rst
+++ b/Simonyi/index.rst
@@ -102,4 +102,16 @@ Most common troubleshooting procedures with associated faults.
 
     Troubleshooting/index.rst
 
+.. _Simonyi-Telescope-Operations-SAL-Scripts:
+.. SAL Scripts
+.. ===========
+
+.. toctree::
+   :glob:
+   :maxdepth: 3
+   :titlesonly:
+   :caption: SAL Scripts
+
+   SAL-Scripts/SimonyiCommonSALScripts.rst
+
 


### PR DESCRIPTION
Simonyi SAL Scripts table moved from Confluence over to ObsOps. I made the format similar to the style we used for AuxTel. Reviews are needed!

Here is the deployed webpage: https://obs-ops.lsst.io/v/RSO-846/Simonyi/SAL-Scripts/SimonyiCommonSALScripts.html